### PR TITLE
SL-59 Increased module version, fixed order overriding data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,3 +40,7 @@
 - BO : 3DS capture fix
 - BO : Updates from bitbucket
 - BO : Module install fix
+
+## [1.0.9] - 2021-07-15
+
+- BO : Fixed invoice_date not being set on order when using module as payment option.

--- a/controllers/front/notify.php
+++ b/controllers/front/notify.php
@@ -55,8 +55,10 @@ class SaferPayOfficialNotifyModuleFrontController extends AbstractSaferPayContro
             $saferPayOrderId = $orderRepo->getIdByOrderId($orderId);
 
             $saferPayOrder = new SaferPayOrder($saferPayOrderId);
-            $order = new Order($orderId);
             $assertResponseBody = $this->assertTransaction($cartId);
+
+            //NOTE must be left below assert action to get newest information.
+            $order = new Order($orderId);
 
             if (
                 in_array($order->payment, SaferPayConfig::SUPPORTED_3DS_PAYMENT_METHODS) &&
@@ -67,6 +69,9 @@ class SaferPayOfficialNotifyModuleFrontController extends AbstractSaferPayContro
                 $secureService->processNotSecuredPayment($order);
                 die($this->module->l('Liability shift is false', self::FILENAME));
             }
+
+            //NOTE to get latest information possible and not override new information.
+            $order = new Order($orderId);
 
             $defaultBehavior = Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR);
             if ((int) $defaultBehavior === SaferPayConfig::DEFAULT_PAYMENT_BEHAVIOR_CAPTURE &&

--- a/controllers/front/notify.php
+++ b/controllers/front/notify.php
@@ -57,6 +57,7 @@ class SaferPayOfficialNotifyModuleFrontController extends AbstractSaferPayContro
             $saferPayOrder = new SaferPayOrder($saferPayOrderId);
             $assertResponseBody = $this->assertTransaction($cartId);
 
+            //TODO look into pipeline design pattern to use when object is modified in multiple places to avoid this issue.
             //NOTE must be left below assert action to get newest information.
             $order = new Order($orderId);
 

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -41,7 +41,7 @@ class SaferPayOfficial extends PaymentModule
     {
         $this->name = 'saferpayofficial';
         $this->author = 'Invertus';
-        $this->version = '1.0.8';
+        $this->version = '1.0.9';
         $this->module_key = '3d3506c3e184a1fe63b936b82bda1bdf';
         $this->displayName = 'SaferpayOfficial';
         $this->description = 'Saferpay Payment module';


### PR DESCRIPTION
$order was being set before Assert action which made changes to the same order.
By using same $order later on to capture payments it caused it to override Assert action changes.