### PR TITLE
IT and FR added to list of supported countries

### DIFF
--- a/src/Config/SaferPayConfig.php
+++ b/src/Config/SaferPayConfig.php
@@ -137,6 +137,8 @@ class SaferPayConfig
         'NL', //Netherlands
         'NO', //Norway
         'SE', //Sweden
+        'IT', //Italy
+        'FR', //France
     ];
 
     const TRANSACTION_METHODS = [

--- a/tests/Unit/Service/PaymentRestrictionValidation/KlarnaPaymentRestrictionValidationTest.php
+++ b/tests/Unit/Service/PaymentRestrictionValidation/KlarnaPaymentRestrictionValidationTest.php
@@ -70,6 +70,14 @@ class KlarnaPaymentRestrictionValidationTest extends UnitTestCase
                 'context' => $this->mockContext('DE', 'LT'),
                 'expectedResult' => false,
             ],
+            [
+                'context' => $this->mockContext('IT', 'EUR'),
+                'expectedResult' => true,
+            ],
+            [
+                'context' => $this->mockContext('FR', 'USD'),
+                'expectedResult' => true,
+            ],
         ];
     }
 


### PR DESCRIPTION
T "IT" and "FR" added to KLARNA_SUPPORTED_COUNTRY_CODES. Assertions  for 'IT' and 'FR' added into into test KlarnaPaymentRestrictionValidationTest.php