### PR TITLE
Fixed exception message rendering if module was configured with inval…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -65,3 +65,7 @@
 ## [1.0.14] - 2022-02-11
 
 - FO : Updated payment methods loading functionality
+
+## [1.0.15] - 2022-05-31
+
+- BO : "Invalid credentials" exception catcher added. 

--- a/controllers/admin/AdminSaferPayOfficialPaymentController.php
+++ b/controllers/admin/AdminSaferPayOfficialPaymentController.php
@@ -33,6 +33,7 @@ use Invertus\SaferPay\Service\SaferPayPaymentCreator;
 use Invertus\SaferPay\Service\SaferPayRestrictionCreator;
 use Invertus\SaferPay\Service\SaferPayObtainPaymentMethods;
 use Invertus\SaferPay\Service\SaferPayRefreshPaymentsService;
+use Invertus\SaferPay\Exception\Api\SaferPayApiException;
 
 class AdminSaferPayOfficialPaymentController extends ModuleAdminController
 {
@@ -58,7 +59,11 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
         // Refresh payments.
         /** @var SaferPayRefreshPaymentsService $refreshPaymentsService */
         $refreshPaymentsService = $this->module->getModuleContainer()->get(SaferPayRefreshPaymentsService::class);
-        $refreshPaymentsService->refreshPayments();
+        try {
+            $refreshPaymentsService->refreshPayments();
+        } catch (SaferPayApiException $exception) {
+            $this->errors[] = $this->l($exception->getMessage());
+        }
 
         if (!Tools::isSubmit('submitAddconfiguration')) {
             return parent::postProcess();
@@ -237,7 +242,7 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
             /** @var \Invertus\SaferPay\Service\SaferPayObtainPaymentMethods $saferPayObtainPaymentMethods */
             $saferPayObtainPaymentMethods = $this->module->getModuleContainer()->get(SaferPayObtainPaymentMethods::class);
             $paymentMethods = $saferPayObtainPaymentMethods->obtainPaymentMethodsNamesAsArray();
-        } catch (\Exception $exception) {
+        } catch (SaferPayApiException $exception) {
             /** @var \Invertus\SaferPay\Service\SaferPayExceptionService $exceptionService */
             $exceptionService = $this->module->getModuleContainer()
                 ->get(\Invertus\SaferPay\Service\SaferPayExceptionService::class);
@@ -281,7 +286,7 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
             $saferPayObtainPaymentMethods = $this->module->getModuleContainer()->get(SaferPayObtainPaymentMethods::class);
 
             return $saferPayObtainPaymentMethods->obtainPaymentMethodsNamesAsArray();
-        } catch (\Exception $exception) {
+        } catch (SaferPayApiException $exception) {
             /** @var \Invertus\SaferPay\Service\SaferPayExceptionService $exceptionService */
             $exceptionService = $this->module->getModuleContainer()
                 ->get(\Invertus\SaferPay\Service\SaferPayExceptionService::class);

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -41,7 +41,7 @@ class SaferPayOfficial extends PaymentModule
     {
         $this->name = 'saferpayofficial';
         $this->author = 'Invertus';
-        $this->version = '1.0.14';
+        $this->version = '1.0.15';
         $this->module_key = '3d3506c3e184a1fe63b936b82bda1bdf';
         $this->displayName = 'SaferpayOfficial';
         $this->description = 'Saferpay Payment module';
@@ -149,7 +149,13 @@ class SaferPayOfficial extends PaymentModule
         /** @var \Invertus\SaferPay\Repository\SaferPayPaymentRepository $paymentRepository */
         $paymentRepository = $this->getModuleContainer()
             ->get(\Invertus\SaferPay\Repository\SaferPayPaymentRepository::class);
-        $paymentMethods = $obtainPaymentMethods->obtainPaymentMethods();
+
+        try {
+            $paymentMethods = $obtainPaymentMethods->obtainPaymentMethods();
+        } catch (\Invertus\SaferPay\Exception\Api\SaferPayApiException $exception) {
+            return [];
+        }
+
         $paymentOptions = [];
 
         /** @var \Invertus\SaferPay\Service\PaymentRestrictionValidation $paymentRestrictionValidation */
@@ -395,7 +401,12 @@ class SaferPayOfficial extends PaymentModule
         /** @var \Invertus\SaferPay\Service\SaferPayObtainPaymentMethods $obtainPaymentMethods */
         $obtainPaymentMethods = $this->getModuleContainer()
             ->get(\Invertus\SaferPay\Service\SaferPayObtainPaymentMethods::class);
-        $paymentMethods = $obtainPaymentMethods->obtainPaymentMethods();
+        try {
+            $paymentMethods = $obtainPaymentMethods->obtainPaymentMethods();
+        } catch (\Invertus\SaferPay\Exception\Api\SaferPayApiException $exception) {
+            return '';
+        }
+
         $paymentOptions = [];
 
         $paymentRestrictionValidation = $this->getModuleContainer()->get(

--- a/src/Service/SaferPayObtainPaymentMethods.php
+++ b/src/Service/SaferPayObtainPaymentMethods.php
@@ -23,7 +23,9 @@
 
 namespace Invertus\SaferPay\Service;
 
+use Exception;
 use Invertus\SaferPay\Api\Request\ObtainPaymentMethodsService;
+use Invertus\SaferPay\Exception\Api\SaferPayApiException;
 use Invertus\SaferPay\Service\Request\ObtainPaymentMethodsObjectCreator;
 
 class SaferPayObtainPaymentMethods

--- a/src/Service/SaferPayRefreshPaymentsService.php
+++ b/src/Service/SaferPayRefreshPaymentsService.php
@@ -24,6 +24,8 @@
 namespace Invertus\SaferPay\Service;
 
 use Invertus\SaferPay\Config\SaferPayConfig;
+use Invertus\SaferPay\Exception\Api\SaferPayApiException;
+use Exception;
 use Invertus\SaferPay\Repository\SaferPayFieldRepository;
 use Invertus\SaferPay\Repository\SaferPayPaymentRepository;
 use Invertus\SaferPay\Repository\SaferPayRestrictionRepository;
@@ -59,7 +61,11 @@ class SaferPayRefreshPaymentsService
         }
 
         // Get payments from API.
-        $paymentsFromAPI = $this->obtainPayments->obtainPaymentMethodsNamesAsArray();
+        try {
+            $paymentsFromAPI = $this->obtainPayments->obtainPaymentMethodsNamesAsArray();
+        } catch (Exception $exception) {
+            throw new SaferPayApiException('Initialize API failed', SaferPayApiException::INITIALIZE);
+        }
 
         $paymentsInfo = [];
         foreach ($activePayments as $payment) {


### PR DESCRIPTION
Before: If client tries to see payment methods in BO->modules->saferpayofficial->Payments tab, he getting "Invalid credentials" exception message.

Now: If client tries to see payment methods in BO->modules->saferpayofficial->Payments tab, he getting user friendly error messages with description. Also Module creates logs about the problem. 
![Screenshot 2022-05-31 at 16 45 00](https://user-images.githubusercontent.com/37298732/171188575-13068d69-e304-48cf-85e1-55e9b3e84059.png)

