### PR TITLE
SL-109 / PS 1.7.1 service for payment validation compability fixed

### DIFF
--- a/config/service.yml
+++ b/config/service.yml
@@ -123,7 +123,7 @@ services:
     Invertus\SaferPay\Service\PaymentRestrictionValidation:
         class: Invertus\SaferPay\Service\PaymentRestrictionValidation
         arguments:
-            - !tagged saferpay.paymentrestriction
+            - [ '@Invertus\SaferPay\Service\PaymentRestrictionValidation\ApplePayPaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\KlarnaPaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation' ]
 
     Invertus\SaferPay\Service\SaferPayLogoCreator:
         class: Invertus\SaferPay\Service\SaferPayLogoCreator

--- a/src/Service/PaymentRestrictionValidation.php
+++ b/src/Service/PaymentRestrictionValidation.php
@@ -28,11 +28,11 @@ use Invertus\SaferPay\Service\PaymentRestrictionValidation\PaymentRestrictionVal
 class PaymentRestrictionValidation
 {
     /**
-     * @var \Traversable
+     * @var array $paymentRestrictionValidators
      */
     private $paymentRestrictionValidators;
 
-    public function __construct(\Traversable $paymentRestrictionValidators)
+    public function __construct(array $paymentRestrictionValidators)
     {
         $this->paymentRestrictionValidators = $paymentRestrictionValidators;
     }


### PR DESCRIPTION
There was a problem with the lower PS version. Client: "Issue is on PS from 1.7.1 to 1.7.4. It seems to be working with 1.6 and works from 1.7.5." 
![image](https://user-images.githubusercontent.com/97019420/183634160-41deb0cd-59df-4de0-b693-c0e06fdf1f4f.png)
So basically all payment restrictions were added to PaymentRestrictionValidation service by !tagged witch on lower versions seen only as a string. A method which is supported only from symphony 3.4, sadly lower Prestashop versions support 2.8-3.0 Symfony. I needed to change the way how to register all restriction services to payment validation.

- Changed services data type from Traversible to Array
- Changed method to register arguments to payment validation
