### PR TITLE
PS 1.7.1 compability fixes with sympfony

### DIFF
--- a/config/service.yml
+++ b/config/service.yml
@@ -123,7 +123,7 @@ services:
     Invertus\SaferPay\Service\PaymentRestrictionValidation:
         class: Invertus\SaferPay\Service\PaymentRestrictionValidation
         arguments:
-            - [ '@Invertus\SaferPay\Service\PaymentRestrictionValidation\ApplePayPaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\KlarnaPaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation' ]
+            - '@Invertus\SaferPay\Provider\PaymentRestrictionProvider'
 
     Invertus\SaferPay\Service\SaferPayLogoCreator:
         class: Invertus\SaferPay\Service\SaferPayLogoCreator
@@ -213,6 +213,13 @@ services:
             - '@=service("adapter.context").getContext()'
             - '@=service("saferpay").name'
             - '@Invertus\SaferPay\Repository\SaferPayFieldRepository'
+
+    Invertus\SaferPay\Provider\PaymentRestrictionProvider:
+        class: Invertus\SaferPay\Provider\PaymentRestrictionProvider
+        arguments:
+            - '@Invertus\SaferPay\Service\PaymentRestrictionValidation\ApplePayPaymentRestrictionValidation'
+            - '@Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation'
+            - '@Invertus\SaferPay\Service\PaymentRestrictionValidation\KlarnaPaymentRestrictionValidation'
 
     Invertus\SaferPay\Service\TransactionFlow\SaferPayTransactionAuthorization:
         class: Invertus\SaferPay\Service\TransactionFlow\SaferPayTransactionAuthorization

--- a/config/service.yml
+++ b/config/service.yml
@@ -123,7 +123,7 @@ services:
     Invertus\SaferPay\Service\PaymentRestrictionValidation:
         class: Invertus\SaferPay\Service\PaymentRestrictionValidation
         arguments:
-            - !tagged saferpay.paymentrestriction
+            - [ '@Invertus\SaferPay\Service\PaymentRestrictionValidation\ApplePayPaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\KlarnaPaymentRestrictionValidation', '@Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation' ]
 
     Invertus\SaferPay\Service\SaferPayLogoCreator:
         class: Invertus\SaferPay\Service\SaferPayLogoCreator

--- a/src/Provider/PaymentRestrictionProvider.php
+++ b/src/Provider/PaymentRestrictionProvider.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ *NOTICE OF LICENSE
+ *
+ *This source file is subject to the Open Software License (OSL 3.0)
+ *that is bundled with this package in the file LICENSE.txt.
+ *It is also available through the world-wide-web at this URL:
+ *http://opensource.org/licenses/osl-3.0.php
+ *If you did not receive a copy of the license and are unable to
+ *obtain it through the world-wide-web, please send an email
+ *to license@prestashop.com so we can send you a copy immediately.
+ *
+ *DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *versions in the future. If you wish to customize PrestaShop for your
+ *needs please refer to http://www.prestashop.com for more information.
+ *
+ *@author INVERTUS UAB www.invertus.eu  <support@invertus.eu>
+ *@copyright SIX Payment Services
+ *@license   SIX Payment Services
+ */
+
+namespace Invertus\SaferPay\Provider;
+
+use Invertus\SaferPay\Service\PaymentRestrictionValidation\ApplePayPaymentRestrictionValidation;
+use Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation;
+use Invertus\SaferPay\Service\PaymentRestrictionValidation\KlarnaPaymentRestrictionValidation;
+
+class PaymentRestrictionProvider
+{
+    /**
+     * @var ApplePayPaymentRestrictionValidation
+     */
+    private $applePayPaymentRestrictionValidation;
+
+    /**
+     * @var BasePaymentRestrictionValidation
+     */
+    private $basePaymentRestrictionValidation;
+
+    /**
+     * @var KlarnaPaymentRestrictionValidation
+     */
+    private $klarnaPaymentRestrictionValidation;
+
+    public function __construct
+    (
+        ApplePayPaymentRestrictionValidation $applePayPaymentRestrictionValidation,
+        BasePaymentRestrictionValidation $basePaymentRestrictionValidation,
+        KlarnaPaymentRestrictionValidation $klarnaPaymentRestrictionValidation
+    )
+    {
+        $this->applePayPaymentRestrictionValidation = $applePayPaymentRestrictionValidation;
+        $this->basePaymentRestrictionValidation = $basePaymentRestrictionValidation;
+        $this->klarnaPaymentRestrictionValidation = $klarnaPaymentRestrictionValidation;
+    }
+
+    /**
+     * @return  array<object>
+     */
+    public function getPaymentValidators(): array
+    {
+        $paymentRestrictions = [];
+        $paymentRestrictions[] = $this->applePayPaymentRestrictionValidation;
+        $paymentRestrictions[] = $this->basePaymentRestrictionValidation;
+        $paymentRestrictions[] = $this->klarnaPaymentRestrictionValidation;
+        return $paymentRestrictions;
+    }
+}

--- a/src/Provider/PaymentRestrictionProvider.php
+++ b/src/Provider/PaymentRestrictionProvider.php
@@ -27,7 +27,7 @@ use Invertus\SaferPay\Service\PaymentRestrictionValidation\ApplePayPaymentRestri
 use Invertus\SaferPay\Service\PaymentRestrictionValidation\BasePaymentRestrictionValidation;
 use Invertus\SaferPay\Service\PaymentRestrictionValidation\KlarnaPaymentRestrictionValidation;
 
-class PaymentRestrictionProvider
+class PaymentRestrictionProvider implements PaymentRestrictionProviderInterface
 {
     /**
      * @var ApplePayPaymentRestrictionValidation
@@ -56,15 +56,12 @@ class PaymentRestrictionProvider
         $this->klarnaPaymentRestrictionValidation = $klarnaPaymentRestrictionValidation;
     }
 
-    /**
-     * @return  array<object>
-     */
     public function getPaymentValidators(): array
     {
-        $paymentRestrictions = [];
-        $paymentRestrictions[] = $this->applePayPaymentRestrictionValidation;
-        $paymentRestrictions[] = $this->basePaymentRestrictionValidation;
-        $paymentRestrictions[] = $this->klarnaPaymentRestrictionValidation;
-        return $paymentRestrictions;
+        return [
+            $this->applePayPaymentRestrictionValidation,
+            $this->basePaymentRestrictionValidation,
+            $this->klarnaPaymentRestrictionValidation
+        ];
     }
 }

--- a/src/Provider/PaymentRestrictionProviderInterface.php
+++ b/src/Provider/PaymentRestrictionProviderInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ *NOTICE OF LICENSE
+ *
+ *This source file is subject to the Open Software License (OSL 3.0)
+ *that is bundled with this package in the file LICENSE.txt.
+ *It is also available through the world-wide-web at this URL:
+ *http://opensource.org/licenses/osl-3.0.php
+ *If you did not receive a copy of the license and are unable to
+ *obtain it through the world-wide-web, please send an email
+ *to license@prestashop.com so we can send you a copy immediately.
+ *
+ *DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *versions in the future. If you wish to customize PrestaShop for your
+ *needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author INVERTUS UAB www.invertus.eu  <support@invertus.eu>
+ * @copyright SIX Payment Services
+ * @license   SIX Payment Services
+ */
+
+namespace Invertus\SaferPay\Provider;
+
+use Invertus\SaferPay\Service\PaymentRestrictionValidation\PaymentRestrictionValidationInterface;
+
+interface PaymentRestrictionProviderInterface
+{
+    /**
+     * @return array<PaymentRestrictionValidationInterface>
+     */
+    public function getPaymentValidators(): array;
+}

--- a/src/Service/PaymentRestrictionValidation.php
+++ b/src/Service/PaymentRestrictionValidation.php
@@ -28,11 +28,11 @@ use Invertus\SaferPay\Service\PaymentRestrictionValidation\PaymentRestrictionVal
 class PaymentRestrictionValidation
 {
     /**
-     * @var \Traversable
+     * @var array
      */
     private $paymentRestrictionValidators;
 
-    public function __construct(\Traversable $paymentRestrictionValidators)
+    public function __construct(array $paymentRestrictionValidators)
     {
         $this->paymentRestrictionValidators = $paymentRestrictionValidators;
     }

--- a/src/Service/PaymentRestrictionValidation.php
+++ b/src/Service/PaymentRestrictionValidation.php
@@ -23,18 +23,19 @@
 
 namespace Invertus\SaferPay\Service;
 
+use Invertus\SaferPay\Provider\PaymentRestrictionProvider;
 use Invertus\SaferPay\Service\PaymentRestrictionValidation\PaymentRestrictionValidationInterface;
 
 class PaymentRestrictionValidation
 {
     /**
-     * @var array
+     * @var PaymentRestrictionProvider
      */
-    private $paymentRestrictionValidators;
+    private $paymentRestrictionProvider;
 
-    public function __construct(array $paymentRestrictionValidators)
+    public function __construct(PaymentRestrictionProvider $paymentRestrictionProvider)
     {
-        $this->paymentRestrictionValidators = $paymentRestrictionValidators;
+        $this->paymentRestrictionProvider = $paymentRestrictionProvider;
     }
 
     /**
@@ -47,11 +48,11 @@ class PaymentRestrictionValidation
     public function isPaymentMethodValid($paymentMethod)
     {
         $success = false;
-
+        $paymentValidators = $this->paymentRestrictionProvider->getPaymentValidators();
         /**
          * @var PaymentRestrictionValidationInterface $paymentRestrictionValidator
          */
-        foreach ($this->paymentRestrictionValidators as $paymentRestrictionValidator) {
+        foreach ($paymentValidators as $paymentRestrictionValidator) {
             if ($paymentRestrictionValidator->supports($paymentMethod)) {
                 $success = $paymentRestrictionValidator->isValid($paymentMethod);
 


### PR DESCRIPTION
Issue: Managed to replicate the issue on newly installed PS and the latest saferPay version.
The issue is on PS from 1.7.1 to 1.7.4. It seems to be working with 1.6 and works from 1.7.5.
![image](https://user-images.githubusercontent.com/97019420/183641749-82e5af5e-9ff7-457c-b0bf-4bfbbb8a9273.png)
Since lower PS versions do not support Symfony 3.4  method to register services in arguments with !tagged i needed to register them in the old fashion way because !tagged [services] were given just as a string. 

- Changed var type since now we are getting array not traversible
- Changed the way services are passed to the argument