### PR TITLE
tos_cms variable fix on PS1.78~ versions and above

### DIFF
--- a/controllers/front/hostedIframe.php
+++ b/controllers/front/hostedIframe.php
@@ -22,6 +22,7 @@
  */
 
 use Invertus\SaferPay\Config\SaferPayConfig;
+use PrestaShop\PrestaShop\Core\Checkout\TermsAndConditions;
 
 class SaferPayOfficialHostedIframeModuleFrontController extends ModuleFrontController
 {
@@ -33,6 +34,7 @@ class SaferPayOfficialHostedIframeModuleFrontController extends ModuleFrontContr
         $this->context->smarty->assign([
             'credit_card_front_url' => "{$this->module->getPathUri()}views/img/example-card/credit-card-front.png",
             'credit_card_back_url' => "{$this->module->getPathUri()}views/img/example-card/credit-card-back.png",
+            'tos_cms' => $this->getDefaultTermsAndConditions()
         ]);
 
         if (SaferPayConfig::isVersion17()) {
@@ -102,5 +104,26 @@ class SaferPayOfficialHostedIframeModuleFrontController extends ModuleFrontContr
                 ".css"
             );
         }
+    }
+
+    protected function getDefaultTermsAndConditions()
+    {
+        $cms = new CMS((int) Configuration::get('PS_CONDITIONS_CMS_ID'), $this->context->language->id);
+
+        if (!Validate::isLoadedObject($cms)) {
+            return false;
+        }
+
+        $link = $this->context->link->getCMSLink($cms, $cms->link_rewrite, (bool) Configuration::get('PS_SSL_ENABLED'));
+
+        $termsAndConditions = new TermsAndConditions();
+        $termsAndConditions
+            ->setText(
+                '[' . $cms->meta_title . ']',
+                $link
+            )
+            ->setIdentifier('terms-and-conditions-footer');
+
+        return $termsAndConditions->format();
     }
 }


### PR DESCRIPTION
In PS 1.78~ version and above checkout/_partials/footer.tpl template starts to use tos_cms variable for Terms and Conditions which comes from OrderController but since our form is hosted iframe we are out of this scope and we lose this variable. Implemented the same function in our controller to get tos_cms variable.
![image](https://user-images.githubusercontent.com/97019420/186110010-6bcbea28-d00a-4ffc-b15a-63acd6ec4a69.png)
![image](https://user-images.githubusercontent.com/97019420/186110054-b51da9a3-1f59-4d10-b35b-8f448081023a.png)

