### PR TITLE
Payment notation fix from SaferPayAPI

### DIFF
--- a/config/service.yml
+++ b/config/service.yml
@@ -263,6 +263,7 @@ services:
 #            - '@=service("adapter.context").getContext()'
             - '@Invertus\SaferPay\Api\Request\ObtainPaymentMethodsService'
             - '@Invertus\SaferPay\Service\Request\ObtainPaymentMethodsObjectCreator'
+            - '@Invertus\SaferPay\Service\SaferPayPaymentNotation'
 
     Invertus\SaferPay\Service\SaferPayRefreshPaymentsService:
         class: Invertus\SaferPay\Service\SaferPayRefreshPaymentsService
@@ -274,3 +275,6 @@ services:
 
     Invertus\SaferPay\Service\SaferPayMailService:
         class: Invertus\SaferPay\Service\SaferPayMailService
+
+    Invertus\SaferPay\Service\SaferPayPaymentNotation:
+        class: Invertus\SaferPay\Service\SaferPayPaymentNotation

--- a/controllers/admin/AdminSaferPayOfficialPaymentController.php
+++ b/controllers/admin/AdminSaferPayOfficialPaymentController.php
@@ -261,7 +261,7 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
         foreach ($paymentMethods as $paymentMethod) {
             $fields[] = [
                 'type' => 'free',
-                'label' => $this->l($paymentMethod),
+                'label' => $this->l($this->formatPaymentNotation($paymentMethod)),
                 'name' => $paymentMethod,
                 'form_group_class' => 'saferpay-group',
             ];
@@ -301,5 +301,33 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
 
             return null;
         }
+    }
+    /**
+     * @param string $notation
+     *
+     * @return string
+     */
+    private function formatPaymentNotation(string $notation)
+    {
+
+        switch ($notation) {
+            case "AMEX":
+                $notation = "AmericanExpress";
+                break;
+            case "DINERS":
+                $notation = "DinersClub";
+                break;
+            case "BONUS":
+                $notation = "BonusCard";
+                break;
+            case "DIRECTDEBIT":
+                $notation = "Lastschrift";
+                break;
+            default:
+                $notation = strtolower($notation);
+                $notation = ucfirst($notation);
+
+        }
+        return $notation;
     }
 }

--- a/controllers/admin/AdminSaferPayOfficialPaymentController.php
+++ b/controllers/admin/AdminSaferPayOfficialPaymentController.php
@@ -30,6 +30,7 @@ use Invertus\SaferPay\Repository\SaferPayRestrictionRepository;
 use Invertus\SaferPay\Service\SaferPayFieldCreator;
 use Invertus\SaferPay\Service\SaferPayLogoCreator;
 use Invertus\SaferPay\Service\SaferPayPaymentCreator;
+use Invertus\SaferPay\Service\SaferPayPaymentNotation;
 use Invertus\SaferPay\Service\SaferPayRestrictionCreator;
 use Invertus\SaferPay\Service\SaferPayObtainPaymentMethods;
 use Invertus\SaferPay\Service\SaferPayRefreshPaymentsService;
@@ -257,11 +258,13 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
 
             return;
         }
+        /** @var \Invertus\SaferPay\Service\SaferPayPaymentNotation $saferPayPaymentNotation */
+        $saferPayPaymentNotation = $this->module->getModuleContainer()->get(SaferPayPaymentNotation::class);
 
         foreach ($paymentMethods as $paymentMethod) {
             $fields[] = [
                 'type' => 'free',
-                'label' => $this->l($this->formatPaymentNotation($paymentMethod)),
+                'label' => $saferPayPaymentNotation->getForDisplay($paymentMethod) ,
                 'name' => $paymentMethod,
                 'form_group_class' => 'saferpay-group',
             ];
@@ -301,33 +304,5 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
 
             return null;
         }
-    }
-    /**
-     * @param string $notation
-     *
-     * @return string
-     */
-    private function formatPaymentNotation(string $notation)
-    {
-
-        switch ($notation) {
-            case "AMEX":
-                $notation = "AmericanExpress";
-                break;
-            case "DINERS":
-                $notation = "DinersClub";
-                break;
-            case "BONUS":
-                $notation = "BonusCard";
-                break;
-            case "DIRECTDEBIT":
-                $notation = "Lastschrift";
-                break;
-            default:
-                $notation = strtolower($notation);
-                $notation = ucfirst($notation);
-
-        }
-        return $notation;
     }
 }

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -173,10 +173,8 @@ class SaferPayOfficial extends PaymentModule
             $imageUrl = ($paymentRepository->isLogoEnabledByName($paymentMethod['paymentMethod']))
                 ? $paymentMethod['logoUrl'] : '';
 
-            $fixedPaymentNotation = $this->fixPaymentNotation($paymentMethod['paymentMethod']);
-
             $isCreditCard = in_array(
-                $fixedPaymentNotation,
+                $paymentMethod['paymentMethod'],
                 \Invertus\SaferPay\Config\SaferPayConfig::TRANSACTION_METHODS
             );
             $isBusinessLicenseEnabled =
@@ -713,25 +711,5 @@ class SaferPayOfficial extends PaymentModule
         }
 
         return true;
-    }
-
-    private function fixPaymentNotation(string $paymentNotation)
-    {
-        $fixedPaymentNotation = strtoupper($paymentNotation);
-        switch ($paymentNotation) {
-            case "AmericanExpress":
-                $fixedPaymentNotation = "AMEX";
-                break;
-            case "DinersClub":
-                $fixedPaymentNotation = "DINERS";
-                break;
-            case "Bonus Card":
-                $fixedPaymentNotation = "BONUS";
-                break;
-            case "Lastschrift":
-                $fixedPaymentNotation = "DIRECTDEBIT";
-                break;
-        }
-        return $fixedPaymentNotation;
     }
 }

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -1,4 +1,7 @@
 <?php
+
+use Invertus\SaferPay\Service\SaferPayPaymentNotation;
+
 /**
  *NOTICE OF LICENSE
  *
@@ -204,6 +207,10 @@ class SaferPayOfficial extends PaymentModule
             $translator =  $this->getModuleContainer()->get(
                 \Invertus\SaferPay\Service\LegacyTranslator::class
             );
+            /** @var SaferPayPaymentNotation $paymentRepository */
+            $saferPayPaymentNotation = $this->getModuleContainer()
+                ->get(SaferPayPaymentNotation::class);
+            $paymentMethod['paymentMethod'] = $saferPayPaymentNotation->getForDisplay($paymentMethod['paymentMethod']);
             $newOption->setModuleName($this->name)
                 ->setCallToActionText($translator->translate($paymentMethod['paymentMethod']))
                 ->setAction($paymentRedirectionProvider->provideRedirectionLinkByPaymentMethod($paymentMethod['paymentMethod']))

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -173,8 +173,10 @@ class SaferPayOfficial extends PaymentModule
             $imageUrl = ($paymentRepository->isLogoEnabledByName($paymentMethod['paymentMethod']))
                 ? $paymentMethod['logoUrl'] : '';
 
+            $fixedPaymentNotation = $this->fixPaymentNotation($paymentMethod['paymentMethod']);
+
             $isCreditCard = in_array(
-                $paymentMethod['paymentMethod'],
+                $fixedPaymentNotation,
                 \Invertus\SaferPay\Config\SaferPayConfig::TRANSACTION_METHODS
             );
             $isBusinessLicenseEnabled =
@@ -711,5 +713,25 @@ class SaferPayOfficial extends PaymentModule
         }
 
         return true;
+    }
+
+    private function fixPaymentNotation(string $paymentNotation)
+    {
+        $fixedPaymentNotation = strtoupper($paymentNotation);
+        switch ($paymentNotation) {
+            case "AmericanExpress":
+                $fixedPaymentNotation = "AMEX";
+                break;
+            case "DinersClub":
+                $fixedPaymentNotation = "DINERS";
+                break;
+            case "Bonus Card":
+                $fixedPaymentNotation = "BONUS";
+                break;
+            case "Lastschrift":
+                $fixedPaymentNotation = "DIRECTDEBIT";
+                break;
+        }
+        return $fixedPaymentNotation;
     }
 }

--- a/src/Service/SaferPayObtainPaymentMethods.php
+++ b/src/Service/SaferPayObtainPaymentMethods.php
@@ -56,7 +56,7 @@ class SaferPayObtainPaymentMethods
         if (!empty($paymentMethodsObject->PaymentMethods)) {
             foreach ($paymentMethodsObject->PaymentMethods as $paymentMethodObject) {
                 $paymentMethods[] = [
-                    'paymentMethod' => $paymentMethodObject->PaymentMethod,
+                    'paymentMethod' => $this->fixPaymentNotation($paymentMethodObject->PaymentMethod),
                     'logoUrl' => $paymentMethodObject->LogoUrl,
                 ];
             }
@@ -86,5 +86,26 @@ class SaferPayObtainPaymentMethods
         }
 
         return $paymentMethodsArray;
+    }
+
+    private function fixPaymentNotation(string $paymentNotation)
+    {
+        $paymentNotation = str_replace(' ', '', $paymentNotation);
+        $fixedPaymentNotation = strtoupper($paymentNotation);
+        switch ($paymentNotation) {
+            case "AmericanExpress":
+                $fixedPaymentNotation = "AMEX";
+                break;
+            case "DinersClub":
+                $fixedPaymentNotation = "DINERS";
+                break;
+            case "BonusCard":
+                $fixedPaymentNotation = "BONUS";
+                break;
+            case "Lastschrift":
+                $fixedPaymentNotation = "DIRECTDEBIT";
+                break;
+        }
+        return $fixedPaymentNotation;
     }
 }

--- a/src/Service/SaferPayObtainPaymentMethods.php
+++ b/src/Service/SaferPayObtainPaymentMethods.php
@@ -32,13 +32,16 @@ class SaferPayObtainPaymentMethods
 {
     private $obtainPaymentMethodsService;
     private $obtainPaymentMethodsObjectCreator;
+    private $saferPayPaymentNotation;
 
     public function __construct(
         ObtainPaymentMethodsService $obtainPaymentMethodsService,
-        ObtainPaymentMethodsObjectCreator $obtainPaymentMethodsObjectCreator
+        ObtainPaymentMethodsObjectCreator $obtainPaymentMethodsObjectCreator,
+        SaferPayPaymentNotation $saferPayPaymentNotation
     ) {
         $this->obtainPaymentMethodsService = $obtainPaymentMethodsService;
         $this->obtainPaymentMethodsObjectCreator = $obtainPaymentMethodsObjectCreator;
+        $this->saferPayPaymentNotation = $saferPayPaymentNotation;
     }
 
     public function obtainPaymentMethods()
@@ -55,8 +58,9 @@ class SaferPayObtainPaymentMethods
 
         if (!empty($paymentMethodsObject->PaymentMethods)) {
             foreach ($paymentMethodsObject->PaymentMethods as $paymentMethodObject) {
+                $paymentNotation = $this->saferPayPaymentNotation->getShortName($paymentMethodObject->PaymentMethod);
                 $paymentMethods[] = [
-                    'paymentMethod' => $this->fixPaymentNotation($paymentMethodObject->PaymentMethod),
+                    'paymentMethod' => $paymentNotation,
                     'logoUrl' => $paymentMethodObject->LogoUrl,
                 ];
             }
@@ -86,26 +90,5 @@ class SaferPayObtainPaymentMethods
         }
 
         return $paymentMethodsArray;
-    }
-
-    private function fixPaymentNotation(string $paymentNotation)
-    {
-        $paymentNotation = str_replace(' ', '', $paymentNotation);
-        $fixedPaymentNotation = strtoupper($paymentNotation);
-        switch ($paymentNotation) {
-            case "AmericanExpress":
-                $fixedPaymentNotation = "AMEX";
-                break;
-            case "DinersClub":
-                $fixedPaymentNotation = "DINERS";
-                break;
-            case "BonusCard":
-                $fixedPaymentNotation = "BONUS";
-                break;
-            case "Lastschrift":
-                $fixedPaymentNotation = "DIRECTDEBIT";
-                break;
-        }
-        return $fixedPaymentNotation;
     }
 }

--- a/src/Service/SaferPayPaymentNotation.php
+++ b/src/Service/SaferPayPaymentNotation.php
@@ -23,11 +23,6 @@
 
 namespace Invertus\SaferPay\Service;
 
-use Exception;
-use Invertus\SaferPay\Api\Request\ObtainPaymentMethodsService;
-use Invertus\SaferPay\Exception\Api\SaferPayApiException;
-use Invertus\SaferPay\Service\Request\ObtainPaymentMethodsObjectCreator;
-
 class SaferPayPaymentNotation
 {
 

--- a/src/Service/SaferPayPaymentNotation.php
+++ b/src/Service/SaferPayPaymentNotation.php
@@ -48,12 +48,12 @@ class SaferPayPaymentNotation
     public function getShortName(string $payment)
     {
         $paymentNotation = str_replace(' ', '', $payment);
-        $fixedPaymentNotation = strtoupper($paymentNotation);
 
         $map = array_flip(self::PAYMENTS);
+        $fixedPaymentNotation = strtoupper($paymentNotation);
 
-        if (isset($map[$fixedPaymentNotation])) {
-            return $map[$fixedPaymentNotation];
+        if (isset($map[$paymentNotation])) {
+            return $map[$paymentNotation];
         }
 
         return $fixedPaymentNotation;

--- a/src/Service/SaferPayPaymentNotation.php
+++ b/src/Service/SaferPayPaymentNotation.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ *NOTICE OF LICENSE
+ *
+ *This source file is subject to the Open Software License (OSL 3.0)
+ *that is bundled with this package in the file LICENSE.txt.
+ *It is also available through the world-wide-web at this URL:
+ *http://opensource.org/licenses/osl-3.0.php
+ *If you did not receive a copy of the license and are unable to
+ *obtain it through the world-wide-web, please send an email
+ *to license@prestashop.com so we can send you a copy immediately.
+ *
+ *DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *versions in the future. If you wish to customize PrestaShop for your
+ *needs please refer to http://www.prestashop.com for more information.
+ *
+ *@author INVERTUS UAB www.invertus.eu  <support@invertus.eu>
+ *@copyright SIX Payment Services
+ *@license   SIX Payment Services
+ */
+
+namespace Invertus\SaferPay\Service;
+
+use Exception;
+use Invertus\SaferPay\Api\Request\ObtainPaymentMethodsService;
+use Invertus\SaferPay\Exception\Api\SaferPayApiException;
+use Invertus\SaferPay\Service\Request\ObtainPaymentMethodsObjectCreator;
+
+class SaferPayPaymentNotation
+{
+
+    const PAYMENTS = [
+        'AMEX' => 'AmericanExpress',
+        'DINERS' => 'DinersClub',
+        'BONUS' => 'BonusCard',
+        'DIRECTDEBIT' => 'Lastschrift'
+    ];
+
+    public function getForDisplay(string $payment)
+    {
+        if (isset(self::PAYMENTS[$payment])) {
+            return self::PAYMENTS[$payment];
+        }
+
+        $notation = strtolower($payment);
+        $notation = ucfirst($notation);
+
+        return $notation;
+    }
+
+    public function getShortName(string $payment)
+    {
+        $paymentNotation = str_replace(' ', '', $payment);
+        $fixedPaymentNotation = strtoupper($paymentNotation);
+
+        $map = array_flip(self::PAYMENTS);
+
+        if (isset($map[$fixedPaymentNotation])) {
+            return $map[$fixedPaymentNotation];
+        }
+
+        return $fixedPaymentNotation;
+    }
+}

--- a/tests/Unit/Service/SaferPayPaymentNotationTest.php
+++ b/tests/Unit/Service/SaferPayPaymentNotationTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ *NOTICE OF LICENSE
+ *
+ *This source file is subject to the Open Software License (OSL 3.0)
+ *that is bundled with this package in the file LICENSE.txt.
+ *It is also available through the world-wide-web at this URL:
+ *http://opensource.org/licenses/osl-3.0.php
+ *If you did not receive a copy of the license and are unable to
+ *obtain it through the world-wide-web, please send an email
+ *to license@prestashop.com so we can send you a copy immediately.
+ *
+ *DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *versions in the future. If you wish to customize PrestaShop for your
+ *needs please refer to http://www.prestashop.com for more information.
+ *
+ *@author INVERTUS UAB www.invertus.eu  <support@invertus.eu>
+ *@copyright SIX Payment Services
+ *@license   SIX Payment Services
+ */
+
+namespace Invertus\SaferPay\Tests\Unit\Service;
+
+use Invertus\SaferPay\Service\SaferPayPaymentNotation;
+use Invertus\SaferPay\Tests\Unit\Tools\UnitTestCase;
+
+class SaferPayPaymentNotationTest extends UnitTestCase
+{
+    /** @dataProvider getPaymentMethodForDisplayDataProvider */
+    public function testGetForDisplay(string $paymentMethod, string $expectedResult)
+    {
+        $result = (new \Invertus\SaferPay\Service\SaferPayPaymentNotation)->getForDisplay($paymentMethod);
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /** @dataProvider getPaymentMethodDataProvider */
+    public function testGetShortName(string $paymentMethod, string $expectedResult)
+    {
+        $result = (new \Invertus\SaferPay\Service\SaferPayPaymentNotation)->getShortName($paymentMethod);
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function getPaymentMethodDataProvider()
+    {
+        return [
+            ['paymentMethod' => 'TWINT', 'expected' => 'TWINT'],
+            ['paymentMethod' => 'VISA', 'expected' => 'VISA'],
+            ['paymentMethod' => 'MasterCard', 'expected' => 'MASTERCARD'],
+            ['paymentMethod' => 'Diners Club', 'expected' => 'DINERS'],
+            ['paymentMethod' => 'American Express', 'expected' => 'AMEX'],
+        ];
+    }
+
+    public function getPaymentMethodForDisplayDataProvider()
+    {
+        return [
+            ['paymentMethod' => 'TWINT', 'expected' => 'Twint'],
+            ['paymentMethod' => 'VISA', 'expected' => 'Visa'],
+            ['paymentMethod' => 'MASTERCARD', 'expected' => 'Mastercard'],
+            ['paymentMethod' => 'DINERS', 'expected' => 'DinersClub'],
+            ['paymentMethod' => 'AMEX', 'expected' => 'AmericanExpress'],
+        ];
+    }
+
+}


### PR DESCRIPTION
After SaferPay's official statement that BackEnd fixes with payment notations will be only in October and only in the newest version, they asked to adopt the module for wrong payment notations from the backend. One of the examples Diner Club payment, from the Safer backend we getting Diners Club but our constant is DINERS and these constants are approved by SaferPay. I created a small function witch adapts payment method notations on saved cards because this place was affected. Card saving now working as intended 
![image](https://user-images.githubusercontent.com/97019420/193049168-b0a0cf9b-963e-4b1d-a590-eb88b634317f.png)
