### PR TITLE
SL-133 checkout issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -86,3 +86,8 @@
 ## [1.0.19] - *
 
 - FO: added ability to save and use saved cards with hosted fields payment
+
+## [1.0.20] - *
+
+- FO: Fixed issue when payment was cancelled due to 3DS failure but Order confirmation was still shown
+- FO: Fixed issue when 3DS failed, but it still captured/authorized payment

--- a/controllers/admin/AdminSaferPayOfficialSettingsController.php
+++ b/controllers/admin/AdminSaferPayOfficialSettingsController.php
@@ -235,8 +235,8 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
                         'title' => $this->l('Behaviour when 3D secure fails'),
                         'validation' => 'isInt',
                         'choices' => [
-                            0 => $this->l('Cancel'),
-                            1 => $this->l('Authorize'),
+                            SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL => $this->l('Cancel'),
+                            SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_AUTHORIZE => $this->l('Authorize'),
                         ],
                         'desc' => $this->l('Default payment behavior for payment without 3-D Secure'),
                         'form_group_class' => 'thumbs_chose',

--- a/controllers/front/iframe.php
+++ b/controllers/front/iframe.php
@@ -24,6 +24,7 @@
 use Invertus\SaferPay\Config\SaferPayConfig;
 use Invertus\SaferPay\Controller\AbstractSaferPayController;
 use Invertus\SaferPay\EntityBuilder\SaferPayOrderBuilder;
+use Invertus\SaferPay\Enum\ControllerName;
 use Invertus\SaferPay\Repository\SaferPayCardAliasRepository;
 use Invertus\SaferPay\Service\SaferPayInitialize;
 
@@ -111,7 +112,7 @@ class SaferPayOfficialIFrameModuleFrontController extends AbstractSaferPayContro
         } catch (Exception $e) {
             $redirectLink = $this->context->link->getModuleLink(
                 $this->module->name,
-                'fail',
+                ControllerName::FAIL,
                 [
                     'cartId' => $this->context->cart->id,
                     'orderId' => Order::getOrderByCartId($this->context->cart->id),

--- a/controllers/front/successHosted.php
+++ b/controllers/front/successHosted.php
@@ -54,23 +54,13 @@ class SaferPayOfficialSuccessHostedModuleFrontController extends AbstractSaferPa
 
         $cart = new Cart($cartId);
         if ($cart->secure_key !== $secureKey) {
-            $redirectLink = $this->context->link->getPageLink(
-                'order',
-                true,
-                null,
-                [
-                    'step' => 1,
-                ]
-            );
-            Tools::redirect($redirectLink);
+            Tools::redirect($this->getOrderLink());
         }
 
         try {
-            /** @var SaferPayOrderRepository $orderRepo */
-            $orderRepo = $this->module->getModuleContainer()->get(SaferPayOrderRepository::class);
-            $saferPayOrderId = $orderRepo->getIdByOrderId($orderId);
+            /** @var SaferPayOrderStatusService $orderStatusService */
+            $orderStatusService = $this->module->getModuleContainer()->get(SaferPayOrderStatusService::class);
 
-            $saferPayOrder = new SaferPayOrder($saferPayOrderId);
             $order = new Order($orderId);
 
             /** @var SaferPayTransactionAuthorization $saferPayTransactionAuthorization */
@@ -82,22 +72,43 @@ class SaferPayOfficialSuccessHostedModuleFrontController extends AbstractSaferPa
                 $selectedCard
             );
 
-            if (!$authResponseBody->getLiability()->getLiabilityShift()) {
-                /** @var SaferPay3DSecureService $secureService */
-                $secureService = $this->module->getModuleContainer()->get(SaferPay3DSecureService::class);
-                $secureService->processNotSecuredPayment($order);
-                Tools::redirect($this->getOrderConfirmationLink($cartId, $moduleId, $orderId, $secureKey));
+            /** @var SaferPay3DSecureService $secureService */
+            $secureService = $this->module->getModuleContainer()->get(SaferPay3DSecureService::class);
+
+            $paymentBehaviourWithout3DS = (int) Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D);
+
+            if (
+                !$authResponseBody->getLiability()->getLiabilityShift() &&
+                $paymentBehaviourWithout3DS === SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL
+            ) {
+                $secureService->cancelPayment($order);
+
+                $this->warning[] = $this->module->l('We couldn\'t authorize your payment. Please try again.', self::FILENAME);
+
+                $this->redirectWithNotifications($this->context->link->getModuleLink(
+                    $this->module->name,
+                    'fail',
+                    [
+                        'cartId' => $cartId,
+                        'secureKey' => $secureKey,
+                        'orderId' => $orderId,
+                        'moduleId' => $moduleId,
+                    ],
+                    true
+                ));
             }
 
-            $defaultBehavior = Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR);
-            if ((int) $defaultBehavior === SaferPayConfig::DEFAULT_PAYMENT_BEHAVIOR_CAPTURE &&
-                !$saferPayOrder->captured
-            ) {
-                /** @var SaferPayOrderStatusService $orderStatusService */
-                $orderStatusService = $this->module->getModuleContainer()->get(SaferPayOrderStatusService::class);
+            $orderStatusService->authorize($order);
+
+            $paymentBehaviour = (int) Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR);
+
+            if ($paymentBehaviour === SaferPayConfig::DEFAULT_PAYMENT_BEHAVIOR_CAPTURE) {
+
                 $orderStatusService->capture($order);
                 Tools::redirect($this->getOrderConfirmationLink($cartId, $moduleId, $orderId, $secureKey));
             }
+
+            Tools::redirect($this->getOrderConfirmationLink($cartId, $moduleId, $orderId, $secureKey));
         } catch (Exception $e) {
             PrestaShopLogger::addLog(
                 sprintf(
@@ -158,6 +169,18 @@ class SaferPayOfficialSuccessHostedModuleFrontController extends AbstractSaferPa
                 'id_module' => $moduleId,
                 'id_order' => $orderId,
                 'key' => $secureKey,
+            ]
+        );
+    }
+
+    private function getOrderLink()
+    {
+        return $this->context->link->getPageLink(
+            'order',
+            true,
+            null,
+            [
+                'step' => 1,
             ]
         );
     }

--- a/controllers/front/successHosted.php
+++ b/controllers/front/successHosted.php
@@ -24,6 +24,7 @@
 use Invertus\SaferPay\Config\SaferPayConfig;
 use Invertus\SaferPay\Controller\AbstractSaferPayController;
 use Invertus\SaferPay\DTO\Response\Assert\AssertBody;
+use Invertus\SaferPay\Enum\ControllerName;
 use Invertus\SaferPay\Repository\SaferPayOrderRepository;
 use Invertus\SaferPay\Service\SaferPay3DSecureService;
 use Invertus\SaferPay\Service\SaferPayOrderStatusService;
@@ -87,7 +88,7 @@ class SaferPayOfficialSuccessHostedModuleFrontController extends AbstractSaferPa
 
                 $this->redirectWithNotifications($this->context->link->getModuleLink(
                     $this->module->name,
-                    'fail',
+                    ControllerName::FAIL,
                     [
                         'cartId' => $cartId,
                         'secureKey' => $secureKey,
@@ -126,7 +127,7 @@ class SaferPayOfficialSuccessHostedModuleFrontController extends AbstractSaferPa
             Tools::redirect(
                 $this->context->link->getModuleLink(
                     $this->module->name,
-                    'fail',
+                    ControllerName::FAIL,
                     [
                         'cartId' => $cartId,
                         'secureKey' => $secureKey,

--- a/controllers/front/successIFrame.php
+++ b/controllers/front/successIFrame.php
@@ -24,6 +24,7 @@
 use Invertus\SaferPay\Api\Request\AuthorizationService;
 use Invertus\SaferPay\Config\SaferPayConfig;
 use Invertus\SaferPay\Controller\AbstractSaferPayController;
+use Invertus\SaferPay\Enum\ControllerName;
 use Invertus\SaferPay\Exception\Api\SaferPayApiException;
 use Invertus\SaferPay\Repository\SaferPayOrderRepository;
 use Invertus\SaferPay\Service\Request\AuthorizationRequestObjectCreator;
@@ -77,7 +78,7 @@ class SaferPayOfficialSuccessIFrameModuleFrontController extends AbstractSaferPa
             $this->warning[] = $this->module->l('We couldn\'t authorize your payment. Please try again.', self::FILENAME);
             $this->redirectWithNotifications($this->context->link->getModuleLink(
                 $this->module->name,
-                'failValidation',
+                ControllerName::FAIL_VALIDATION,
                 [
                     'cartId' => $cartId,
                     'secureKey' => $secureKey,
@@ -104,7 +105,7 @@ class SaferPayOfficialSuccessIFrameModuleFrontController extends AbstractSaferPa
 
             $this->redirectWithNotifications($this->context->link->getModuleLink(
                 $this->module->name,
-                'fail',
+                ControllerName::FAIL,
                 [
                     'cartId' => $cartId,
                     'secureKey' => $secureKey,

--- a/controllers/front/successIFrame.php
+++ b/controllers/front/successIFrame.php
@@ -29,6 +29,7 @@ use Invertus\SaferPay\Repository\SaferPayOrderRepository;
 use Invertus\SaferPay\Service\Request\AuthorizationRequestObjectCreator;
 use Invertus\SaferPay\Service\SaferPay3DSecureService;
 use Invertus\SaferPay\Service\SaferPayOrderStatusService;
+use Invertus\SaferPay\Service\TransactionFlow\SaferPayTransactionAuthorization;
 
 class SaferPayOfficialSuccessIFrameModuleFrontController extends AbstractSaferPayController
 {
@@ -51,134 +52,82 @@ class SaferPayOfficialSuccessIFrameModuleFrontController extends AbstractSaferPa
         $orderId = Tools::getValue('orderId');
         $secureKey = Tools::getValue('secureKey');
         $selectedCard = Tools::getValue('selectedCard');
-        $isDirectPayment = Tools::getValue('directPayment');
         $moduleId = Tools::getValue('moduleId');
 
         $cart = new Cart($cartId);
         if ($cart->secure_key !== $secureKey) {
-            $redirectLink = $this->context->link->getPageLink(
-                'order',
-                true,
-                null,
-                [
-                    'step' => 1,
-                ]
-            );
-
-            Tools::redirect($redirectLink);
+            Tools::redirect($this->getOrderLink());
         }
 
-        /** @var AuthorizationRequestObjectCreator $authRequestCreator */
-        $authRequestCreator = $this->module->getModuleContainer()->get(AuthorizationRequestObjectCreator::class);
+        /** @var SaferPayTransactionAuthorization $saferPayTransactionAuthorization */
+        $saferPayTransactionAuthorization = $this->module->getModuleContainer()->get(SaferPayTransactionAuthorization::class);
 
-        /** @var SaferPayOrderRepository $orderRepo */
-        $orderRepo = $this->module->getModuleContainer()->get('saferpay.order.repository');
+        /** @var SaferPayOrderStatusService $orderStatusService */
+        $orderStatusService = $this->module->getModuleContainer()->get(SaferPayOrderStatusService::class);
 
-        $saferPayOrderId = $orderRepo->getIdByOrderId($orderId);
-        $saferPayOrder = new SaferPayOrder($saferPayOrderId);
-        $saveCard = (int) $selectedCard === SaferPayConfig::CREDIT_CARD_OPTION_SAVE;
-        $authRequest = $authRequestCreator->create($saferPayOrder->token, $saveCard);
-
-        /** @var AuthorizationService $authorizeService */
-        $authorizeService = $this->module->getModuleContainer()->get(AuthorizationService::class);
         $order = new Order($orderId);
-        if (!$isDirectPayment) {
-            try {
-                $response = $authorizeService->authorize(
-                    $authRequest
-                );
-                $authResponse = $authorizeService->createObjectsFromAuthorizationResponse(
-                    $response,
-                    $saferPayOrderId,
-                    $order->id_customer,
-                    $selectedCard
-                );
-            } catch (SaferPayApiException $e) {
-                $this->warning[] = $this->module->l(
-                    'We couldn\'t authorize your payment. Please try again.',
-                    self::FILENAME
-                );
-                $failUrl = $this->context->link->getModuleLink(
-                    $this->module->name,
-                    'failValidation',
-                    [
-                        'cartId' => $cartId,
-                        'secureKey' => $secureKey,
-                        'orderId' => $orderId,
-                        \Invertus\SaferPay\Config\SaferPayConfig::IS_BUSINESS_LICENCE => true,
-                    ],
-                    true
-                );
-                $this->redirectWithNotifications($failUrl);
-            }
-            $saferPayOrder->transaction_id = $authResponse->getTransaction()->getId();
-            if ($authResponse->getTransaction()->getStatus() === 'AUTHORIZED') {
-                $saferPayOrder->authorized = 1;
-            }
-            if ($authResponse->getTransaction()->getStatus() === 'CAPTURED') {
-                $saferPayOrder->authorized = 1;
-                $saferPayOrder->captured = 1;
-                $order->setCurrentState(_SAFERPAY_PAYMENT_COMPLETED_);
-            }
-            $saferPayOrder->update();
 
-            $newOrderStatus = _SAFERPAY_PAYMENT_AUTHORIZED_;
-            $order->setCurrentState($newOrderStatus);
-
-            if ($authResponse->getLiability()->getThreeDs() && !$authResponse->getLiability()->getLiabilityShift()) {
-                /** @var SaferPay3DSecureService $secureService */
-                $secureService = $this->module->getModuleContainer()->get(SaferPay3DSecureService::class);
-                $secureService->processNotSecuredPayment($order);
-                $isOrderCanceled = $secureService->isSaferPayOrderCanceled($orderId);
-                if ($isOrderCanceled) {
-                    $this->warning[] = $this->module->l(
-                        'We couldn\'t authorize your payment. Please try again.',
-                        self::FILENAME
-                    );
-                    $failUrl = $this->context->link->getModuleLink(
-                        $this->module->name,
-                        'failIFrame',
-                        [
-                            'cartId' => $cartId,
-                            'secureKey' => $secureKey,
-                            'orderId' => $orderId,
-                            'moduleId' => $moduleId,
-                        ],
-                        true
-                    );
-                    $this->redirectWithNotifications($failUrl);
-                }
-
-                return;
-            }
-        }
-
-        if ($authResponse->getLiability()->getThreeDs()) {
-            $defaultBehavior = Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR);
-            if ((int) $defaultBehavior === SaferPayConfig::DEFAULT_PAYMENT_BEHAVIOR_CAPTURE) {
-                /** @var SaferPayOrderStatusService $orderStatusService */
-                $orderStatusService = $this->module->getModuleContainer()->get(SaferPayOrderStatusService::class);
-                $orderStatusService->capture($order);
-            }
-        }
-
-        $isDirectPayment = Tools::getValue('directPayment');
-        if ($isDirectPayment) {
-            $orderLink = $this->context->link->getPageLink(
-                'order-confirmation',
-                true,
-                null,
-                [
-                    'id_cart' => $cartId,
-                    'id_module' => $moduleId,
-                    'id_order' => $orderId,
-                    'key' => $secureKey,
-                ]
+        try {
+            $authResponseBody = $saferPayTransactionAuthorization->authorize(
+                $orderId,
+                (int) $selectedCard === SaferPayConfig::CREDIT_CARD_OPTION_SAVE,
+                $selectedCard
             );
-            if ($isDirectPayment) {
-                Tools::redirect($orderLink);
-            }
+        } catch (SaferPayApiException $e) {
+            $this->warning[] = $this->module->l('We couldn\'t authorize your payment. Please try again.', self::FILENAME);
+            $this->redirectWithNotifications($this->context->link->getModuleLink(
+                $this->module->name,
+                'failValidation',
+                [
+                    'cartId' => $cartId,
+                    'secureKey' => $secureKey,
+                    'orderId' => $orderId,
+                    \Invertus\SaferPay\Config\SaferPayConfig::IS_BUSINESS_LICENCE => true,
+                ],
+                true
+            ));
         }
+
+        /** @var SaferPay3DSecureService $secureService */
+        $secureService = $this->module->getModuleContainer()->get(SaferPay3DSecureService::class);
+
+        $paymentBehaviourWithout3DS = (int) Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D);
+
+        if (
+            $authResponseBody->getLiability()->getThreeDs() &&
+            !$authResponseBody->getLiability()->getLiabilityShift() &&
+            $paymentBehaviourWithout3DS === SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL
+        ) {
+            $secureService->cancelPayment($order);
+
+            $this->warning[] = $this->module->l('We couldn\'t authorize your payment. Please try again.', self::FILENAME);
+
+            $this->redirectWithNotifications($this->context->link->getModuleLink(
+                $this->module->name,
+                'fail',
+                [
+                    'cartId' => $cartId,
+                    'secureKey' => $secureKey,
+                    'orderId' => $orderId,
+                    'moduleId' => $moduleId,
+                ],
+                true
+            ));
+        }
+
+        $orderStatusService->authorize($order);
+
+        $paymentBehaviour = (int) Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR);
+
+        if (
+            $paymentBehaviour === SaferPayConfig::DEFAULT_PAYMENT_BEHAVIOR_CAPTURE &&
+            $authResponseBody->getLiability()->getThreeDs()
+        ) {
+            $orderStatusService->capture($order);
+            Tools::redirect($this->getOrderConfirmationLink($cartId, $moduleId, $orderId, $secureKey));
+        }
+
+        Tools::redirect($this->getOrderConfirmationLink($cartId, $moduleId, $orderId, $secureKey));
     }
 
     public function initContent()
@@ -251,5 +200,40 @@ class SaferPayOfficialSuccessIFrameModuleFrontController extends AbstractSaferPa
                 '/modules/saferpayofficial/views/js/front/saferpay_iframe.js'
             );
         }
+    }
+
+    /**
+     * @param int $cartId
+     * @param int $moduleId
+     * @param int $orderId
+     * @param string $secureKey
+     *
+     * @return string
+     */
+    private function getOrderConfirmationLink($cartId, $moduleId, $orderId, $secureKey)
+    {
+        return $this->context->link->getPageLink(
+            'order-confirmation',
+            true,
+            null,
+            [
+                'id_cart' => $cartId,
+                'id_module' => $moduleId,
+                'id_order' => $orderId,
+                'key' => $secureKey,
+            ]
+        );
+    }
+
+    private function getOrderLink()
+    {
+        return $this->context->link->getPageLink(
+            'order',
+            true,
+            null,
+            [
+                'step' => 1,
+            ]
+        );
     }
 }

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -41,7 +41,7 @@ class SaferPayOfficial extends PaymentModule
     {
         $this->name = 'saferpayofficial';
         $this->author = 'Invertus';
-        $this->version = '1.0.19';
+        $this->version = '1.0.20';
         $this->module_key = '3d3506c3e184a1fe63b936b82bda1bdf';
         $this->displayName = 'SaferpayOfficial';
         $this->description = 'Saferpay Payment module';

--- a/src/Config/SaferPayConfig.php
+++ b/src/Config/SaferPayConfig.php
@@ -248,6 +248,9 @@ class SaferPayConfig
 
     const EMAIL_ALERTS_MODULE_NAME = 'ps_emailalerts';
 
+    const PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL = 0;
+    const PAYMENT_BEHAVIOR_WITHOUT_3D_AUTHORIZE = 1;
+
     public static function getConfigSuffix()
     {
         if (Configuration::get(self::TEST_MODE)) {

--- a/src/Service/SaferPay3DSecureService.php
+++ b/src/Service/SaferPay3DSecureService.php
@@ -58,27 +58,9 @@ class SaferPay3DSecureService
     /**
      * @param Order $order
      */
-    public function processNotSecuredPayment(Order $order)
+    public function cancelPayment(Order $order)
     {
-        $defaultBehavior = Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D);
-        if ($defaultBehavior) {
-            return;
-        }
         $this->cartDuplicationService->restoreCart($order->id_cart);
         $this->orderStatusService->cancel($order);
-    }
-
-    /**
-     * @param $orderId
-     * @return bool
-     * @throws \PrestaShopDatabaseException
-     * @throws \PrestaShopException
-     */
-    public function isSaferPayOrderCanceled($orderId)
-    {
-        $saferPayOrderId = $this->orderRepository->getIdByOrderId($orderId);
-        $saferPayOrder = new SaferPayOrder($saferPayOrderId);
-
-        return $saferPayOrder->canceled;
     }
 }

--- a/src/Service/SaferPayInitialize.php
+++ b/src/Service/SaferPayInitialize.php
@@ -26,6 +26,7 @@ namespace Invertus\SaferPay\Service;
 use Context;
 use Exception;
 use Invertus\SaferPay\Api\Request\InitializeService;
+use Invertus\SaferPay\Enum\ControllerName;
 use Invertus\SaferPay\Exception\Api\SaferPayApiException;
 use Invertus\SaferPay\Service\Request\InitializeRequestObjectCreator;
 use Order;
@@ -90,7 +91,7 @@ class SaferPayInitialize
         );
         $notifyUrl = $this->context->link->getModuleLink(
             $this->module->name,
-            'notify',
+            ControllerName::NOTIFY,
             [
                 'success' => 1,
                 'cartId' => $this->context->cart->id,
@@ -101,7 +102,7 @@ class SaferPayInitialize
         );
         $failUrl = $this->context->link->getModuleLink(
             $this->module->name,
-            'failValidation',
+            ControllerName::FAIL_VALIDATION,
             [
                 'cartId' => $this->context->cart->id,
                 'secureKey' => $this->context->cart->secure_key,

--- a/src/Service/SaferPayOrderStatusService.php
+++ b/src/Service/SaferPayOrderStatusService.php
@@ -33,6 +33,7 @@ use Invertus\SaferPay\Api\Request\CaptureService;
 use Invertus\SaferPay\Api\Request\RefundService;
 use Invertus\SaferPay\Config\SaferPayConfig;
 use Invertus\SaferPay\DTO\Request\PendingNotification;
+use Invertus\SaferPay\Enum\ControllerName;
 use Invertus\SaferPay\Exception\Api\SaferPayApiException;
 use Invertus\SaferPay\Repository\SaferPayOrderRepository;
 use Invertus\SaferPay\Service\Request\CancelRequestObjectCreator;
@@ -229,7 +230,7 @@ class SaferPayOrderStatusService
             $saferPayAssert->payment_method === SaferPayConfig::PAYMENT_PAYDIREKT) {
             $pendingNotify = $this->context->getLink()->getModuleLink(
                 $this->module->name,
-                'pendingNotify',
+                ControllerName::PENDING_NOTIFY,
                 [
                     'success' => 1,
                     'cartId' => $cart->id,

--- a/src/Service/TransactionFlow/SaferPayTransactionAuthorization.php
+++ b/src/Service/TransactionFlow/SaferPayTransactionAuthorization.php
@@ -84,7 +84,6 @@ class SaferPayTransactionAuthorization
     public function authorize($orderId, $saveCard, $selectedCard)
     {
         $saferPayOrder = $this->getSaferPayOrder($orderId);
-        $order = new Order($orderId);
 
         $authRequest = $this->authRequestCreator->create($saferPayOrder->token, $saveCard);
         $authResponse = $this->authorizationService->authorize($authRequest);
@@ -98,8 +97,6 @@ class SaferPayTransactionAuthorization
 
         $saferPayOrder->transaction_id = $assertBody->getTransaction()->getId();
         $saferPayOrder->update();
-
-        $this->orderStatusService->authorize($order);
 
         return $assertBody;
     }


### PR DESCRIPTION
Fixed issue when payment was cancelled due to 3DS failure but Order confirmation was still shown, changed it to order page step 1.
Fixed issue when 3DS failed but it still captured/authorized payment based on settings prior to canceling. 