### PR TITLE
SL-142/maestro payment method notation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -95,3 +95,4 @@
 ## [1.0.21] - *
 
 - FO: Fixed issue with payments not being displayed when currency option was not set to "ALL"
+- BO: Fixed issue with "Maestro Intl." not being enabled in BO

--- a/src/Service/SaferPayPaymentNotation.php
+++ b/src/Service/SaferPayPaymentNotation.php
@@ -31,7 +31,8 @@ class SaferPayPaymentNotation
         'DINERS' => 'DinersClub',
         'BONUS' => 'BonusCard',
         'DIRECTDEBIT' => 'Lastschrift',
-        'POSTFINANCE' => 'PostEFinance'
+        'POSTFINANCE' => 'PostEFinance',
+        'MAESTRO' => 'Maestro-Intl.'
     ];
 
     public function getForDisplay($payment)


### PR DESCRIPTION
Adding different name as MAESTRO is available while MAESTRO-INTL. is not.