### PR TITLE
SL-158-sofort-payment-issue

### DIFF
--- a/src/Config/SaferPayConfig.php
+++ b/src/Config/SaferPayConfig.php
@@ -133,7 +133,8 @@ class SaferPayConfig
         'WLCryptoPayments' => self::PAYMENT_WLCRYPTOPAYMENTS,
         'Postcard' => self::PAYMENT_POSTCARD,
         'BonusCard' => self::PAYMENT_BONUS,
-        'Lastschrift' => self::PAYMENT_LASTSCHRIFT
+        'Lastschrift' => self::PAYMENT_LASTSCHRIFT,
+        'SOFORTUEBERWEISUNG' => self::PAYMENT_SOFORT
     ];
 
     const FIELD_SUPPORTED_PAYMENT_METHODS = [


### PR DESCRIPTION
https://invertus.atlassian.net/browse/SL-158

problem:
![image](https://user-images.githubusercontent.com/130041316/230570849-356054d7-3cf0-4219-9ce9-d21995ede1e8.png)
![image](https://user-images.githubusercontent.com/130041316/230570900-c40a2ce6-ae8b-4ff5-9118-ab06763d6e79.png)


Api obtains sofort payment method's full name SOFORTUEBERWISUNG, but then requires short name SOFORT
When changing the key name the post initialization method works, because we change the long name to short


![image](https://user-images.githubusercontent.com/130041316/230571240-ffe8433c-5bc0-4f34-af62-0fd58ad1c58a.png)

