### PR TITLE
SL-155/API-version-increase-fixes

### DIFF
--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -61,21 +61,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
         }
 
         try {
-            $assertResponseBody = $this->assertTransaction($orderId);
-
-            if ($assertResponseBody->getTransaction()->getStatus() === 'CANCELED') {
-                Tools::redirect($this->context->link->getModuleLink(
-                    $this->module->name,
-                    'failValidation',
-                    [
-                        'cartId' => $cartId,
-                        'orderId' => $orderId,
-                        'secureKey' => $secureKey
-                    ],
-                    true
-                ));
-            }
-
             Tools::redirect($this->context->link->getModuleLink(
                 $this->module->name,
                 $this->getSuccessControllerName($isBusinessLicence, $fieldToken),
@@ -100,20 +85,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
                 ]
             ));
         }
-    }
-
-    /**
-     * @param $cartId
-     * @return AssertBody
-     * @throws Exception
-     */
-    private function assertTransaction($orderId)
-    {
-        /** @var SaferPayTransactionAssertion $transactionAssert */
-        $transactionAssert = $this->module->getService(SaferPayTransactionAssertion::class);
-        $assertionResponse = $transactionAssert->assert($orderId);
-
-        return $assertionResponse;
     }
 
     private function getSuccessControllerName($isBusinessLicence, $fieldToken)

--- a/controllers/front/successHosted.php
+++ b/controllers/front/successHosted.php
@@ -76,7 +76,8 @@ class SaferPayOfficialSuccessHostedModuleFrontController extends AbstractSaferPa
             if (
                 !$authResponseBody->getLiability()->getLiabilityShift() &&
                 in_array($order->payment, SaferPayConfig::SUPPORTED_3DS_PAYMENT_METHODS) &&
-                $paymentBehaviourWithout3DS === SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL
+                $paymentBehaviourWithout3DS === SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL ||
+                $authResponseBody->getTransaction()->getStatus() === 'CANCELED'
             ) {
                 $orderStatusService->cancel($order);
 

--- a/controllers/front/successIFrame.php
+++ b/controllers/front/successIFrame.php
@@ -92,7 +92,8 @@ class SaferPayOfficialSuccessIFrameModuleFrontController extends AbstractSaferPa
         if (
             !$authResponseBody->getLiability()->getLiabilityShift() &&
             in_array($order->payment, SaferPayConfig::SUPPORTED_3DS_PAYMENT_METHODS) &&
-            $paymentBehaviourWithout3DS === SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL
+            $paymentBehaviourWithout3DS === SaferPayConfig::PAYMENT_BEHAVIOR_WITHOUT_3D_CANCEL ||
+            $authResponseBody->getTransaction()->getStatus() === 'CANCELED'
         ) {
             $orderStatusService->cancel($order);
 


### PR DESCRIPTION
Removed transaction assert in return.php controller in order to avoid double authorization issues, instead implemented redirection to other controllers where they do the authorization accordingly.

changed success controller to check the transaction and if it fails then redirect to failValidate.