### PR TITLE
SL-176: unset notification container for previous API version

### DIFF
--- a/src/DTO/Request/Initialize/InitializeRequest.php
+++ b/src/DTO/Request/Initialize/InitializeRequest.php
@@ -68,12 +68,12 @@ class InitializeRequest
     private $returnUrl;
 
     /**
-     * @var array
+     * @var SaferPayNotification|null
      */
     private $notification;
 
     /**
-     * @var array
+     * @var DeliveryAddressForm
      */
     private $deliveryAddressForm;
 
@@ -124,7 +124,7 @@ class InitializeRequest
         Payment              $payment,
         Payer                $payer,
         ReturnUrl            $returnUrl,
-        SaferPayNotification $notification,
+                             $notification,
         DeliveryAddressForm  $deliveryAddressForm,
                              $configSet,
                              $cssUrl,
@@ -214,17 +214,21 @@ class InitializeRequest
             'ReturnUrl' => [
                 'Url' => $this->returnUrl->getReturnUrl(),
             ],
-            'Notification' => [
-                'PayerEmail' => $this->notification->getPayerEmail(),
-                'MerchantEmails' => [$this->notification->getMerchantEmail()],
-                'SuccessNotifyUrl' => $this->notification->getNotifyUrl(),
-                'FailNotifyUrl' => $this->notification->getNotifyUrl(),
-            ],
             'DeliveryAddressForm' => [
                 'AddressSource' => $this->deliveryAddressForm->getAddressSource(),
                 'MandatoryFields' => $this->deliveryAddressForm->getMandatoryFields(),
             ],
         ];
+
+        if ($this->notification !== null) {
+            $return['Notification'] = [
+                'PayerEmail' => $this->notification->getPayerEmail(),
+                'MerchantEmails' => [$this->notification->getMerchantEmail()],
+                'SuccessNotifyUrl' => $this->notification->getNotifyUrl(),
+                'FailNotifyUrl' => $this->notification->getNotifyUrl(),
+            ];
+        }
+
         if ($this->configSet) {
             $return['ConfigSet'] = $this->configSet;
         }

--- a/src/Service/Request/InitializeRequestObjectCreator.php
+++ b/src/Service/Request/InitializeRequestObjectCreator.php
@@ -27,6 +27,7 @@ use Cart;
 use Configuration;
 use Customer;
 use Invertus\SaferPay\Config\SaferPayConfig;
+use Invertus\SaferPay\DTO\Request\RequestHeader;
 use Invertus\SaferPay\DTO\Request\Initialize\InitializeRequest;
 use Invertus\SaferPay\DTO\Request\Payer;
 
@@ -51,6 +52,7 @@ class InitializeRequestObjectCreator
         $deliveryAddressId,
         $invoiceAddressId,
         $customerId,
+        $isBusinessLicence,
         $alias = null,
         $fieldToken = null
     ) {
@@ -63,7 +65,7 @@ class InitializeRequestObjectCreator
         $payment = $this->requestObjectCreator->createPayment($cart, $totalPrice);
         $payer = new Payer();
         $returnUrl = $this->requestObjectCreator->createReturnUrl($returnUrl);
-        $notification = $this->requestObjectCreator->createNotification($customerEmail, $notifyUrl);
+        $notification = ($isBusinessLicence && version_compare(Configuration::get(RequestHeader::SPEC_VERSION), '1.35', '<')) ? null : $this->requestObjectCreator->createNotification($customerEmail, $notifyUrl);
         $deliveryAddressForm = $this->requestObjectCreator->createDeliveryAddressForm();
         $configSet = Configuration::get(SaferPayConfig::CONFIGURATION_NAME);
         $cssUrl = Configuration::get(SaferPayConfig::CSS_FILE);

--- a/src/Service/SaferPayInitialize.php
+++ b/src/Service/SaferPayInitialize.php
@@ -114,6 +114,7 @@ class SaferPayInitialize
             $this->context->cart->id_address_delivery,
             $this->context->cart->id_address_invoice,
             $this->context->cart->id_customer,
+            $isBusinessLicence,
             $alias,
             $fieldToken
         );


### PR DESCRIPTION
Task: https://invertus.atlassian.net/browse/SL-176
Branch: SL-176 from master

Changes:
- added functionality to unset Notification Container from API Request for endpoint `Payment/v1/Transaction/Initialize` (related to `isBusinessLicense`) and for SaferPay API version lower than 1.35

For isBusinessLicense = 1 (Notification container is unset):
![image](https://github.com/Invertus/saferpayofficial/assets/19492394/7127f478-9c3a-48e8-8e23-9cf3ba73ca31)


For isBusinessLicense = 0 (Notification container is present):
![image](https://github.com/Invertus/saferpayofficial/assets/19492394/88678e7d-0974-43d7-89dd-eb613f676150)
