### PR TITLE
SL-183/update-local-API-version-configuration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -129,3 +129,7 @@
 - BO : ReturnSuccessUrl and ReturnFailUrl replaced by ReturnUrl container
 - BO : NotificationUrl container replaced by SuccessNotificationUrl and FailNotificationUrl,
 - BO : Display from BillingAddressForm and DeliveryAddressForm containers replaced by AddressSource
+
+## [1.1.4] - *
+
+- BO : Fixed API version issue

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -36,7 +36,7 @@ class SaferPayOfficial extends PaymentModule
     {
         $this->name = 'saferpayofficial';
         $this->author = 'Invertus';
-        $this->version = '1.1.3';
+        $this->version = '1.1.4';
         $this->module_key = '3d3506c3e184a1fe63b936b82bda1bdf';
         $this->displayName = 'SaferpayOfficial';
         $this->description = 'Saferpay Payment module';

--- a/upgrade/install-1.1.4.php
+++ b/upgrade/install-1.1.4.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ *NOTICE OF LICENSE
+ *
+ *This source file is subject to the Open Software License (OSL 3.0)
+ *that is bundled with this package in the file LICENSE.txt.
+ *It is also available through the world-wide-web at this URL:
+ *http://opensource.org/licenses/osl-3.0.php
+ *If you did not receive a copy of the license and are unable to
+ *obtain it through the world-wide-web, please send an email
+ *to license@prestashop.com so we can send you a copy immediately.
+ *
+ *DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *versions in the future. If you wish to customize PrestaShop for your
+ *needs please refer to http://www.prestashop.com for more information.
+ *
+ *@author INVERTUS UAB www.invertus.eu  <support@invertus.eu>
+ *@copyright SIX Payment Services
+ *@license   SIX Payment Services
+ */
+
+use Invertus\SaferPay\Config\SaferPayConfig;
+use Invertus\SaferPay\DTO\Request\RequestHeader;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+function upgrade_module_1_1_4($module)
+{
+    Configuration::updateValue(RequestHeader::SPEC_VERSION, SaferPayConfig::API_VERSION);
+    Configuration::updateValue(RequestHeader::SPEC_REFUND_VERSION, SaferPayConfig::API_VERSION);
+
+    return true;
+}


### PR DESCRIPTION
We need to update the local configuration of the API version already stored in the database to avoid errors.