### PR TITLE
SL-197: authorize error on iframe payment method

### DIFF
--- a/src/Api/Request/AssertService.php
+++ b/src/Api/Request/AssertService.php
@@ -78,8 +78,13 @@ class AssertService
 
         $assertApi = self::ASSERT_API_PAYMENT;
 
+        //TODO: refactor this to use authorize request.
+        // naming is weird. With transaction, we do a request to an authorize endpoint but name it assert ?
+        // also we call authorize method in some of the success controllers, so if we leave the logic here,
+        // we get an error with TRANSACTION_IN_WRONG_STATE
         if ($saferPayOrder->is_transaction) {
-            $assertApi = self::ASSERT_API_TRANSACTION;
+            return [];
+//          $assertApi = self::ASSERT_API_TRANSACTION;
         }
 
         try {
@@ -93,7 +98,7 @@ class AssertService
     }
 
     /**
-     * @param object $responseBody
+     * @param array $responseBody
      * @param int $saferPayOrderId
      *
      * @return AssertBody

--- a/src/Api/Request/AssertService.php
+++ b/src/Api/Request/AssertService.php
@@ -98,7 +98,7 @@ class AssertService
     }
 
     /**
-     * @param array $responseBody
+     * @param object $responseBody
      * @param int $saferPayOrderId
      *
      * @return AssertBody

--- a/src/DTO/Request/Assert/AssertRequest.php
+++ b/src/DTO/Request/Assert/AssertRequest.php
@@ -29,6 +29,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+// TODO: A lot of these request are the same, we can at least put them under an interface
+
 class AssertRequest
 {
 

--- a/src/Service/TransactionFlow/SaferPayTransactionAssertion.php
+++ b/src/Service/TransactionFlow/SaferPayTransactionAssertion.php
@@ -83,6 +83,10 @@ class SaferPayTransactionAssertion
         $assertRequest = $this->assertRequestCreator->create($orderId);
         $assertResponse = $this->assertionService->assert($assertRequest, $saferPayOrder->id);
 
+        if (empty($assertResponse)) {
+            return null;
+        }
+
         $assertBody = $this->assertionService->createObjectsFromAssertResponse(
             $assertResponse,
             $saferPayOrder->id


### PR DESCRIPTION
Fixed an error on checkout with an transaction type payment method on hosted/iframe method.

Since the initial front controller does an assertTransaction method so if it's a transaction it send a request to the authorize endpoint ;D and then on success controllers we call authorizeTransaction endpoint again and thus get an error.

A lot of refactoring is needed, but for now providing a solution for the issue.