### PR TITLE
SL-203: match shop language with iframe

### DIFF
--- a/src/Service/Request/InitializeRequestObjectCreator.php
+++ b/src/Service/Request/InitializeRequestObjectCreator.php
@@ -30,6 +30,7 @@ use Invertus\SaferPay\Config\SaferPayConfig;
 use Invertus\SaferPay\DTO\Request\RequestHeader;
 use Invertus\SaferPay\DTO\Request\Initialize\InitializeRequest;
 use Invertus\SaferPay\DTO\Request\Payer;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -68,6 +69,7 @@ class InitializeRequestObjectCreator
         $totalPrice = (int) (round($totalPrice));
         $payment = $this->requestObjectCreator->createPayment($cart, $totalPrice);
         $payer = new Payer();
+        $payer->setLanguageCode($cart->getAssociatedLanguage()->iso_code);
         $returnUrl = $this->requestObjectCreator->createReturnUrl($returnUrl);
         $notification = ($isBusinessLicence && version_compare(Configuration::get(RequestHeader::SPEC_VERSION), '1.35', '<')) ? null : $this->requestObjectCreator->createNotification($customerEmail, $notifyUrl);
         $deliveryAddressForm = $this->requestObjectCreator->createDeliveryAddressForm();

--- a/src/Service/Request/InitializeRequestObjectCreator.php
+++ b/src/Service/Request/InitializeRequestObjectCreator.php
@@ -69,7 +69,12 @@ class InitializeRequestObjectCreator
         $totalPrice = (int) (round($totalPrice));
         $payment = $this->requestObjectCreator->createPayment($cart, $totalPrice);
         $payer = new Payer();
-        $payer->setLanguageCode($cart->getAssociatedLanguage()->iso_code);
+
+        $languageCode = !empty($cart->getAssociatedLanguage()->iso_code)
+            ? $cart->getAssociatedLanguage()->iso_code
+            : 'en';
+
+        $payer->setLanguageCode($languageCode);
         $returnUrl = $this->requestObjectCreator->createReturnUrl($returnUrl);
         $notification = ($isBusinessLicence && version_compare(Configuration::get(RequestHeader::SPEC_VERSION), '1.35', '<')) ? null : $this->requestObjectCreator->createNotification($customerEmail, $notifyUrl);
         $deliveryAddressForm = $this->requestObjectCreator->createDeliveryAddressForm();


### PR DESCRIPTION
Previously the LanguageCode was not being set, so the hosted iframe would always be set to default lang

![image](https://github.com/Invertus/saferpayofficial/assets/130041316/742afd32-f9ae-4191-8d0a-c1af96e9bc29)