### PR TITLE
SL-206: apple pay desktop

### DIFF
--- a/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
+++ b/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
@@ -74,9 +74,9 @@ class ApplePayPaymentRestrictionValidation implements PaymentRestrictionValidati
 
     private function isMacDesktop()
     {
-//        if (SaferPayConfig::isTestMode()) {
-//            return true;
-//        }
+        if (SaferPayConfig::isTestMode()) {
+            return true;
+        }
 
         $device = $this->context->getDeviceDetect();
 

--- a/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
+++ b/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
@@ -80,6 +80,6 @@ class ApplePayPaymentRestrictionValidation implements PaymentRestrictionValidati
 
         $device = $this->context->getDeviceDetect();
 
-        return $device === \Context::DEVICE_COMPUTER && preg_match('/macintosh|mac os x|mac_powerpc/i', $_SERVER['HTTP_USER_AGENT']) != false;
+        return $device === \Context::DEVICE_COMPUTER && preg_match('/macintosh|mac os x|mac_powerpc/i', $_SERVER['HTTP_USER_AGENT']);
     }
 }

--- a/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
+++ b/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
@@ -74,12 +74,12 @@ class ApplePayPaymentRestrictionValidation implements PaymentRestrictionValidati
 
     private function isMacDesktop()
     {
-        if (SaferPayConfig::isTestMode()) {
-            return true;
-        }
+//        if (SaferPayConfig::isTestMode()) {
+//            return true;
+//        }
 
         $device = $this->context->getDeviceDetect();
 
-        return $device === \Context::DEVICE_COMPUTER && preg_match('/macintosh|mac os x|mac_powerpc/i', $_SERVER['HTTP_USER_AGENT']);
+        return $device === \Context::DEVICE_COMPUTER && (int) preg_match('/macintosh|mac os x|mac_powerpc/i', $_SERVER['HTTP_USER_AGENT']);
     }
 }

--- a/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
+++ b/src/Service/PaymentRestrictionValidation/ApplePayPaymentRestrictionValidation.php
@@ -80,6 +80,6 @@ class ApplePayPaymentRestrictionValidation implements PaymentRestrictionValidati
 
         $device = $this->context->getDeviceDetect();
 
-        return $device === \Context::DEVICE_COMPUTER && preg_match('/macintosh|mac os x|mac_powerpc/i', $_SERVER['HTTP_USER_AGENT']) !== false;
+        return $device === \Context::DEVICE_COMPUTER && preg_match('/macintosh|mac os x|mac_powerpc/i', $_SERVER['HTTP_USER_AGENT']) != false;
     }
 }


### PR DESCRIPTION
removed strict type to allow 0 == false checking

tested on browser stack with safari.
