### PR TITLE
SL-204/ Default payment behavior on capture bug fix

### DIFF
--- a/controllers/front/notify.php
+++ b/controllers/front/notify.php
@@ -91,6 +91,8 @@ class SaferPayOfficialNotifyModuleFrontController extends AbstractSaferPayContro
                 $checkoutData->setOrderStatus($assertResponseBody->getTransaction()->getStatus());
 
                 $checkoutProcessor->run($checkoutData);
+
+                $orderId = Order::getIdByCartId($cart->id);
             }
 
             //TODO look into pipeline design pattern to use when object is modified in multiple places to avoid this issue.

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -21,10 +21,12 @@
  *@license   SIX Payment Services
  */
 
+use Invertus\SaferPay\Api\Enum\TransactionStatus;
 use Invertus\SaferPay\Config\SaferPayConfig;
 use Invertus\SaferPay\Controller\AbstractSaferPayController;
 use Invertus\SaferPay\Core\Payment\DTO\CheckoutData;
 use Invertus\SaferPay\Enum\ControllerName;
+use Invertus\SaferPay\Service\SaferPayOrderStatusService;
 use Invertus\SaferPay\Service\TransactionFlow\SaferPayTransactionAssertion;
 use Invertus\SaferPay\Processor\CheckoutProcessor;
 
@@ -65,22 +67,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
             ]));
         }
 
-        // At this point notify controller possibly already created and order
-        if (Order::getIdByCartId($cartId)) {
-            Tools::redirect($this->context->link->getModuleLink(
-                $this->module->name,
-                $this->getSuccessControllerName($isBusinessLicence, $fieldToken),
-                [
-                    'cartId' => $cartId,
-                    'orderId' => $orderId,
-                    'moduleId' => $moduleId,
-                    'secureKey' => $secureKey,
-                    'selectedCard' => $selectedCard,
-                ],
-                true
-            ));
-        }
-
         try {
             /** @var SaferPayTransactionAssertion $transactionAssert */
             $transactionAssert = $this->module->getService(SaferPayTransactionAssertion::class);
@@ -100,6 +86,14 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
             $checkoutProcessor->run($checkoutData);
 
             $orderId = \Order::getIdByCartId($cartId);
+
+            if ((int) Configuration::get(SaferPayConfig::PAYMENT_BEHAVIOR) === SaferPayConfig::DEFAULT_PAYMENT_BEHAVIOR_CAPTURE &&
+                $assertionResponse->getTransaction()->getStatus() !== TransactionStatus::CAPTURED
+            ) {
+                /** @var SaferPayOrderStatusService $orderStatusService */
+                $orderStatusService = $this->module->getService(SaferPayOrderStatusService::class);
+                $orderStatusService->capture(new Order($orderId));
+            }
 
             Tools::redirect($this->context->link->getModuleLink(
                 $this->module->name,

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -65,6 +65,22 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
             ]));
         }
 
+        // At this point notify controller possibly already created and order
+        if (Order::getIdByCartId($cartId)) {
+            Tools::redirect($this->context->link->getModuleLink(
+                $this->module->name,
+                $this->getSuccessControllerName($isBusinessLicence, $fieldToken),
+                [
+                    'cartId' => $cartId,
+                    'orderId' => $orderId,
+                    'moduleId' => $moduleId,
+                    'secureKey' => $secureKey,
+                    'selectedCard' => $selectedCard,
+                ],
+                true
+            ));
+        }
+
         try {
             /** @var SaferPayTransactionAssertion $transactionAssert */
             $transactionAssert = $this->module->getService(SaferPayTransactionAssertion::class);


### PR DESCRIPTION
Setting to capture on authorization bug fix.
On successfull payment saferpay api reaching two endpoints. Notify and return. 
On notify controller found that orderId is not refreshed after order creation.
Added additional validation on return controller to check is saferpay already reached notify controller.