### PR TITLE
[SL-240,SV-15] Fix infinite loop after payment

### DIFF
--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -25,6 +25,7 @@ use Invertus\SaferPay\Config\SaferPayConfig;
 use Invertus\SaferPay\Controller\Front\CheckoutController;
 use Invertus\SaferPay\Core\Payment\DTO\CheckoutData;
 use Invertus\SaferPay\Enum\ControllerName;
+use Invertus\SaferPay\Repository\SaferPayOrderRepository;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -43,7 +44,81 @@ class SaferPayOfficialAjaxModuleFrontController extends ModuleFrontController
             case 'submitHostedFields':
                 $this->submitHostedFields();
                 break;
+            case 'getStatus':
+                $this->processGetStatus();
+                break;
         }
+    }
+
+    /**
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    protected function processGetStatus()
+    {
+        header('Content-Type: application/json;charset=UTF-8');
+        /** @var SaferPayOrderRepository $saferPayOrderRepository */
+        $saferPayOrderRepository = $this->module->getService(SaferPayOrderRepository::class);
+        $cartId = Tools::getValue('cartId');
+        $secureKey = Tools::getValue('secureKey');
+        $isBusinessLicence = (int) Tools::getValue(SaferPayConfig::IS_BUSINESS_LICENCE);
+        $fieldToken = Tools::getValue('fieldToken');
+        $moduleId = $this->module->id;
+        $selectedCard = Tools::getValue('selectedCard');
+        $saferPayOrderId = $saferPayOrderRepository->getIdByCartId($cartId);
+        $saferPayOrder = new SaferPayOrder($saferPayOrderId);
+
+        if (!$saferPayOrder->id || $saferPayOrder->canceled) {
+            $this->ajaxDie(json_encode([
+                'isFinished' => true,
+                'href' => $this->getFailControllerLink($cartId, $secureKey, $moduleId)
+            ]));
+        }
+
+        $this->ajaxDie(json_encode([
+            'saferpayOrder' => json_encode($saferPayOrder),
+            'isFinished' => $saferPayOrder->authorized || $saferPayOrder->captured || $saferPayOrder->pending,
+            'href' => $this->context->link->getModuleLink(
+                $this->module->name,
+                $this->getSuccessControllerName($isBusinessLicence, $fieldToken),
+                [
+                    'cartId' => $cartId,
+                    'orderId' => $saferPayOrder->id_order,
+                    'moduleId' => $moduleId,
+                    'secureKey' => $secureKey,
+                    'selectedCard' => $selectedCard,
+                ]
+            )
+        ]));
+    }
+
+    private function getFailControllerLink($cartId, $secureKey, $moduleId)
+    {
+        return $this->context->link->getModuleLink(
+            $this->module->name,
+            ControllerName::FAIL,
+            [
+                'cartId' => $cartId,
+                'secureKey' => $secureKey,
+                'moduleId' => $moduleId,
+            ],
+            true
+        );
+    }
+
+    private function getSuccessControllerName($isBusinessLicence, $fieldToken)
+    {
+        $successController = ControllerName::SUCCESS;
+
+        if ($isBusinessLicence) {
+            $successController = ControllerName::SUCCESS_IFRAME;
+        }
+
+        if ($fieldToken) {
+            $successController = ControllerName::SUCCESS_HOSTED;
+        }
+
+        return $successController;
     }
 
     private function submitHostedFields()

--- a/controllers/front/notify.php
+++ b/controllers/front/notify.php
@@ -153,6 +153,12 @@ class SaferPayOfficialNotifyModuleFrontController extends AbstractSaferPayContro
             $orderId = (int) $order->id;
 
             if ($orderId) {
+                $saferPayCapturedStatus = (int) Configuration::get(\Invertus\SaferPay\Config\SaferPayConfig::SAFERPAY_PAYMENT_COMPLETED);
+
+                if ((int) $order->current_state === $saferPayCapturedStatus) {
+                    die($this->module->l('Order already created', self::FILENAME));
+                }
+
                 // assuming order transaction was declined
                 $order->setCurrentState(_SAFERPAY_PAYMENT_AUTHORIZATION_FAILED_);
             }

--- a/controllers/front/notify.php
+++ b/controllers/front/notify.php
@@ -66,8 +66,14 @@ class SaferPayOfficialNotifyModuleFrontController extends AbstractSaferPayContro
             $secureKey
         ));
 
-        if (!$lockResult->isSuccessful()) {
-            die($this->module->l('Lock already exist', self::FILENAME));
+        if (!SaferPayConfig::isVersion17()) {
+            if ($lockResult > 200) {
+                die($this->module->l('Lock already exists', self::FILENAME));
+            }
+        } else {
+            if (!$lockResult->isSuccessful()) {
+                die($this->module->l('Lock already exists', self::FILENAME));
+            }
         }
 
         if ($cart->orderExists()) {
@@ -95,8 +101,8 @@ class SaferPayOfficialNotifyModuleFrontController extends AbstractSaferPayContro
             );
 
             $checkoutData->setOrderStatus($transactionStatus);
-
             $checkoutProcessor->run($checkoutData);
+
             $orderId = $this->getOrderId($cartId);
 
             //TODO look into pipeline design pattern to use when object is modified in multiple places to avoid this issue.

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -175,10 +175,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
         );
     }
 
-    private function assertTransaction($cartId) {
-
-    }
-
     /**
      * @param int $cartId
      *

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -27,7 +27,6 @@ use Invertus\SaferPay\Controller\AbstractSaferPayController;
 use Invertus\SaferPay\DTO\Response\Assert\AssertBody;
 use Invertus\SaferPay\Enum\ControllerName;
 use Invertus\SaferPay\Exception\Api\SaferPayApiException;
-use Invertus\SaferPay\Repository\SaferPayOrderRepository;
 use Invertus\SaferPay\Service\SaferPayOrderStatusService;
 use Invertus\SaferPay\Service\TransactionFlow\SaferPayTransactionAssertion;
 use Invertus\SaferPay\Service\TransactionFlow\SaferPayTransactionAuthorization;
@@ -43,8 +42,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
     public function postProcess()
     {
         $cartId = (int) Tools::getValue('cartId');
-        $isBusinessLicence = (int) Tools::getValue(SaferPayConfig::IS_BUSINESS_LICENCE);
-        $selectedCard = (int) Tools::getValue('selectedCard');
         $order = new Order($this->getOrderId($cartId));
 
         if (!$order->id) {
@@ -52,17 +49,13 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
         }
 
         try {
-            if ($isBusinessLicence) {
-                $response = $this->executeTransaction($cartId, $selectedCard);
-            } else {
-                $response = $this->assertTransaction($cartId);
-            }
-
-            \PrestaShopLogger::addLog($response->getTransaction()->getStatus());
+            /** @var SaferPayTransactionAssertion $transactionAssert */
+            $transactionAssert = $this->module->getService(SaferPayTransactionAssertion::class);
+            $transactionResponse = $transactionAssert->assert($cartId, false);
 
             /** @var SaferPayOrderStatusService $orderStatusService */
             $orderStatusService = $this->module->getService(SaferPayOrderStatusService::class);
-            if ($response->getTransaction()->getStatus() === TransactionStatus::PENDING) {
+            if ($transactionResponse->getTransaction()->getStatus() === TransactionStatus::PENDING) {
                 $orderStatusService->setPending($order);
             }
         } catch (SaferPayApiException $e) {
@@ -75,13 +68,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
      */
     public function initContent()
     {
-        if (Tools::getValue('ajax')) {
-            $this->processAjax();
-            exit;
-        }
-
-        parent::initContent();
-
         $cartId = Tools::getValue('cartId');
         $secureKey = Tools::getValue('secureKey');
         $isBusinessLicence = (int) Tools::getValue(SaferPayConfig::IS_BUSINESS_LICENCE);
@@ -136,7 +122,7 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
             'checkStatusEndpoint',
             $this->context->link->getModuleLink(
                 $this->module->name,
-                'return',
+                'ajax',
                 [
                     'ajax' => 1,
                     'action' => 'getStatus',
@@ -155,62 +141,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
         $this->setTemplate('saferpay_wait_16.tpl');
     }
 
-    protected function processAjax()
-    {
-        if (empty($this->context->customer->id)) {
-            return;
-        }
-
-        switch (Tools::getValue('action')) {
-            case 'getStatus':
-                $this->processGetStatus();
-                break;
-        }
-
-        exit;
-    }
-
-    /**
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    protected function processGetStatus()
-    {
-        header('Content-Type: application/json;charset=UTF-8');
-        /** @var SaferPayOrderRepository $saferPayOrderRepository */
-        $saferPayOrderRepository = $this->module->getService(SaferPayOrderRepository::class);
-        $cartId = Tools::getValue('cartId');
-        $secureKey = Tools::getValue('secureKey');
-        $isBusinessLicence = (int) Tools::getValue(SaferPayConfig::IS_BUSINESS_LICENCE);
-        $fieldToken = Tools::getValue('fieldToken');
-        $moduleId = $this->module->id;
-        $selectedCard = Tools::getValue('selectedCard');
-        $saferPayOrderId = $saferPayOrderRepository->getIdByCartId($cartId);
-        $saferPayOrder = new SaferPayOrder($saferPayOrderId);
-
-        if (!$saferPayOrder->id || $saferPayOrder->canceled) {
-            $this->ajaxDie(json_encode([
-                'isFinished' => true,
-                'href' => $this->getFailControllerLink($cartId, $secureKey, $moduleId)
-            ]));
-        }
-
-        $this->ajaxDie(json_encode([
-            'isFinished' => $saferPayOrder->authorized || $saferPayOrder->captured || $saferPayOrder->pending,
-            'href' => $this->context->link->getModuleLink(
-                $this->module->name,
-                $this->getSuccessControllerName($isBusinessLicence, $fieldToken),
-                [
-                    'cartId' => $cartId,
-                    'orderId' => $saferPayOrder->id_order,
-                    'moduleId' => $moduleId,
-                    'secureKey' => $secureKey,
-                    'selectedCard' => $selectedCard,
-                ]
-            )
-        ]));
-    }
-
     private function getSuccessControllerName($isBusinessLicence, $fieldToken)
     {
         $successController = ControllerName::SUCCESS;
@@ -224,20 +154,6 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
         }
 
         return $successController;
-    }
-
-    private function getFailControllerLink($cartId, $secureKey, $moduleId)
-    {
-        return $this->context->link->getModuleLink(
-            $this->module->name,
-            ControllerName::FAIL,
-            [
-                'cartId' => $cartId,
-                'secureKey' => $secureKey,
-                'moduleId' => $moduleId,
-            ],
-            true
-        );
     }
 
     /**
@@ -260,10 +176,7 @@ class SaferPayOfficialReturnModuleFrontController extends AbstractSaferPayContro
     }
 
     private function assertTransaction($cartId) {
-        /** @var SaferPayTransactionAssertion $transactionAssert */
-        $transactionAssert = $this->module->getService(SaferPayTransactionAssertion::class);
 
-        return $transactionAssert->assert($cartId);
     }
 
     /**

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -155,9 +155,8 @@ class SaferPayOfficial extends PaymentModule
             return '';
         }
 
-        //@todo: translate and move to template if needed when requirements are clear
-        return 'Your payment is still being processed by your bank. This can take up to 5 days (120 hours). Once we receive the final status, we will notify you immediately.
-Thank you for your patience!';
+        return $this->l('Your payment is still being processed by your bank. This can take up to 5 days (120 hours). Once we receive the final status, we will notify you immediately.
+Thank you for your patience!');
     }
 
     public function hookActionObjectOrderPaymentAddAfter($params)

--- a/saferpayofficial.php
+++ b/saferpayofficial.php
@@ -21,30 +21,6 @@
  *@license   SIX Payment Services
  */
 
-use Invertus\SaferPay\Builder\OrderConfirmationMessageTemplate;
-use Invertus\SaferPay\Config\SaferPayConfig;
-use Invertus\SaferPay\Core\Order\Verification\CanSendOrderConfirmationEmail;
-use Invertus\SaferPay\Exception\Api\SaferPayApiException;
-use Invertus\SaferPay\Install\Installer;
-use Invertus\SaferPay\Install\Uninstaller;
-use Invertus\SaferPay\Presentation\Loader\PaymentFormAssetLoader;
-use Invertus\SaferPay\Presenter\AdminOrderPagePresenter;
-use Invertus\SaferPay\Presenter\AssertPresenter;
-use Invertus\SaferPay\Provider\PaymentRedirectionProvider;
-use Invertus\SaferPay\Provider\PaymentTypeProvider;
-use Invertus\SaferPay\Repository\SaferPayCardAliasRepository;
-use Invertus\SaferPay\Repository\SaferPayOrderRepository;
-use Invertus\SaferPay\Repository\SaferPayPaymentRepository;
-use Invertus\SaferPay\Service\LegacyTranslator;
-use Invertus\SaferPay\Service\PaymentRestrictionValidation;
-use Invertus\SaferPay\Service\SaferPayCartService;
-use Invertus\SaferPay\Service\SaferPayErrorDisplayService;
-use Invertus\SaferPay\Service\SaferPayMailService;
-use Invertus\SaferPay\Service\SaferPayObtainPaymentMethods;
-use Invertus\SaferPay\Service\SaferPayPaymentNotation;
-use Invertus\SaferPay\ServiceProvider\LeagueServiceContainerProvider;
-use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -81,7 +57,7 @@ class SaferPayOfficial extends PaymentModule
 
     public function getContent()
     {
-        if (Configuration::get(SaferPayConfig::USERNAME)) {
+        if (Configuration::get(\Invertus\SaferPay\Config\SaferPayConfig::USERNAME)) {
             Tools::redirectAdmin($this->context->link->getAdminLink(self::ADMIN_PAYMENTS_CONTROLLER));
         }
         Tools::redirectAdmin($this->context->link->getAdminLink(self::ADMIN_SETTINGS_CONTROLLER));
@@ -89,7 +65,7 @@ class SaferPayOfficial extends PaymentModule
 
     public function install()
     {
-        $installer = new Installer($this);
+        $installer = new \Invertus\SaferPay\Install\Installer($this);
 
         if (!parent::install()) {
             return false;
@@ -104,7 +80,7 @@ class SaferPayOfficial extends PaymentModule
 
     public function uninstall()
     {
-        $uninstaller = new Uninstaller($this);
+        $uninstaller = new \Invertus\SaferPay\Install\Uninstaller($this);
         if (!$uninstaller->uninstall()) {
             $this->_errors += $uninstaller->getErrors();
             return false;
@@ -114,7 +90,7 @@ class SaferPayOfficial extends PaymentModule
 
     public function getTabs()
     {
-        $installer = new Installer($this);
+        $installer = new \Invertus\SaferPay\Install\Installer($this);
 
         return $installer->tabs();
     }
@@ -133,7 +109,7 @@ class SaferPayOfficial extends PaymentModule
     }
     public function getService($service)
     {
-        $containerProvider = new LeagueServiceContainerProvider();
+        $containerProvider = new \Invertus\SaferPay\ServiceProvider\LeagueServiceContainerProvider();
 
         return $containerProvider->getService($service);
     }
@@ -147,8 +123,9 @@ class SaferPayOfficial extends PaymentModule
         /** @var Order $psOrder */
         $psOrder = $params['order'];
 
-        /** @var SaferPayOrderRepository $repository */
-        $repository = $this->getService(SaferPayOrderRepository::class);
+        /** @var \Invertus\SaferPay\Repository\SaferPayOrderRepository $repository */
+        $repository = $this->getService(\Invertus\SaferPay\Repository\SaferPayOrderRepository::class);
+
 
         $sfOrder = $repository->getByOrderId((int) $psOrder->id);
         if (!$sfOrder->pending) {
@@ -172,8 +149,8 @@ Thank you for your patience!');
             return;
         }
 
-        /** @var SaferPayOrderRepository $saferPayOrderRepository */
-        $saferPayOrderRepository = $this->getService(SaferPayOrderRepository::class);
+        /** @var \Invertus\SaferPay\Repository\SaferPayOrderRepository $saferPayOrderRepository */
+        $saferPayOrderRepository = $this->getService(\Invertus\SaferPay\Repository\SaferPayOrderRepository::class);
 
         $orders = Order::getByReference($orderPayment->order_reference);
 
@@ -203,31 +180,32 @@ Thank you for your patience!');
     public function hookPaymentOptions($params)
     {
         /** @var Invertus\SaferPay\Service\SaferPayCartService $assertService */
-        $cartService = $this->getService(SaferPayCartService::class);
+        $cartService = $this->getService(\Invertus\SaferPay\Service\SaferPayCartService::class);
         if (!$cartService->isCurrencyAvailable($params['cart'])) {
             return;
         }
 
-        /** @var PaymentTypeProvider $paymentTypeProvider */
-        $paymentTypeProvider = $this->getService(PaymentTypeProvider::class);
+        /** @var \Invertus\SaferPay\Provider\PaymentTypeProvider $paymentTypeProvider */
+        $paymentTypeProvider = $this->getService(\Invertus\SaferPay\Provider\PaymentTypeProvider::class);
 
-        /** @var SaferPayObtainPaymentMethods $obtainPaymentMethods */
-        $obtainPaymentMethods = $this->getService(SaferPayObtainPaymentMethods::class);
-        /** @var SaferPayPaymentRepository $paymentRepository */
-        $paymentRepository = $this->getService(SaferPayPaymentRepository::class);
+        /** @var \Invertus\SaferPay\Service\SaferPayObtainPaymentMethods $obtainPaymentMethods */
+        $obtainPaymentMethods = $this->getService(\Invertus\SaferPay\Service\SaferPayObtainPaymentMethods::class);
+        /** @var \Invertus\SaferPay\Repository\SaferPayPaymentRepository $paymentRepository */
+        $paymentRepository = $this->getService(\Invertus\SaferPay\Repository\SaferPayPaymentRepository::class);
 
         try {
             $paymentMethods = $obtainPaymentMethods->obtainPaymentMethods();
-        } catch (SaferPayApiException $exception) {
+        } catch (\Invertus\SaferPay\Exception\Api\SaferPayApiException $exception) {
             return [];
         }
 
         $paymentOptions = [];
 
-        /** @var PaymentRestrictionValidation $paymentRestrictionValidation */
+        /** @var \Invertus\SaferPay\Service\PaymentRestrictionValidation $paymentRestrictionValidation */
         $paymentRestrictionValidation = $this->getService(
-            PaymentRestrictionValidation::class
+            \Invertus\SaferPay\Service\PaymentRestrictionValidation::class
         );
+
 
         foreach ($paymentMethods as $paymentMethod) {
             $paymentMethod['paymentMethod'] = str_replace(' ', '', $paymentMethod['paymentMethod']);
@@ -241,20 +219,20 @@ Thank you for your patience!');
 
             $isCreditCard = in_array(
                 $paymentMethod['paymentMethod'],
-                SaferPayConfig::TRANSACTION_METHODS
+                \Invertus\SaferPay\Config\SaferPayConfig::TRANSACTION_METHODS
             );
             $isBusinessLicenseEnabled =
                 Configuration::get(
-                    SaferPayConfig::BUSINESS_LICENSE
-                    . SaferPayConfig::getConfigSuffix()
+                    \Invertus\SaferPay\Config\SaferPayConfig::BUSINESS_LICENSE
+                    . \Invertus\SaferPay\Config\SaferPayConfig::getConfigSuffix()
                 );
 
-            /** @var SaferPayCardAliasRepository $cardAliasRep */
+            /** @var \Invertus\SaferPay\Repository\SaferPayCardAliasRepository $cardAliasRep */
             $cardAliasRep = $this->getService(
-                SaferPayCardAliasRepository::class
+                \Invertus\SaferPay\Repository\SaferPayCardAliasRepository::class
             );
             $isCreditCardSavingEnabled = Configuration::get(
-                SaferPayConfig::CREDIT_CARD_SAVE
+                \Invertus\SaferPay\Config\SaferPayConfig::CREDIT_CARD_SAVE
             );
             $selectedCard = 0;
             if ($this->context->customer->is_guest) {
@@ -262,15 +240,15 @@ Thank you for your patience!');
                 $selectedCard = -1;
             }
 
-            /** @var PaymentRedirectionProvider $paymentRedirectionProvider */
-            $paymentRedirectionProvider = $this->getService(PaymentRedirectionProvider::class);
+            /** @var \Invertus\SaferPay\Provider\PaymentRedirectionProvider $paymentRedirectionProvider */
+            $paymentRedirectionProvider = $this->getService(\Invertus\SaferPay\Provider\PaymentRedirectionProvider::class);
 
-            $newOption = new PaymentOption();
+            $newOption = new \PrestaShop\PrestaShop\Core\Payment\PaymentOption();
             $translator = $this->getService(
-                LegacyTranslator::class
+                \Invertus\SaferPay\Service\LegacyTranslator::class
             );
-            /** @var SaferPayPaymentNotation $saferPayPaymentNotation */
-            $saferPayPaymentNotation = $this->getService(SaferPayPaymentNotation::class);
+            /** @var \Invertus\SaferPay\Service\SaferPayPaymentNotation $saferPayPaymentNotation */
+            $saferPayPaymentNotation = $this->getService(\Invertus\SaferPay\Service\SaferPayPaymentNotation::class);
             $paymentMethodName = $saferPayPaymentNotation->getForDisplay($paymentMethod['paymentMethod']);
 
             $inputs = [
@@ -285,7 +263,7 @@ Thank you for your patience!');
                     'value' => $selectedCard,
                 ],
             ];
-            
+
             if ($isCreditCardSavingEnabled && $isCreditCard && $isBusinessLicenseEnabled) {
                 $currentDate = date('Y-m-d h:i:s');
 
@@ -337,7 +315,7 @@ Thank you for your patience!');
 
     public function hookDisplayAdminOrderTabContent(array $params)
     {
-        $isVersionAbove177 = SaferPayConfig::isVersionAbove177();
+        $isVersionAbove177 = \Invertus\SaferPay\Config\SaferPayConfig::isVersionAbove177();
 
         return !$isVersionAbove177 ? false : $this->displayInAdminOrderPage($params);
     }
@@ -345,20 +323,20 @@ Thank you for your patience!');
 
     public function hookDisplayAdminOrder(array $params)
     {
-        $isVersionAbove177 = SaferPayConfig::isVersionAbove177();
+        $isVersionAbove177 = \Invertus\SaferPay\Config\SaferPayConfig::isVersionAbove177();
 
         return $isVersionAbove177 ? false : $this->displayInAdminOrderPage($params);
     }
 
     public function hookActionFrontControllerSetMedia()
     {
-        /** @var PaymentFormAssetLoader $paymentFormAssetsLoader */
-        $paymentFormAssetsLoader = $this->getService(PaymentFormAssetLoader::class);
+        /** @var \Invertus\SaferPay\Presentation\Loader\PaymentFormAssetLoader $paymentFormAssetsLoader */
+        $paymentFormAssetsLoader = $this->getService(\Invertus\SaferPay\Presentation\Loader\PaymentFormAssetLoader::class);
 
         $paymentFormAssetsLoader->register($this->context->controller);
 
         if ($this->context->controller instanceof OrderController) {
-            if (SaferPayConfig::isVersion17()) {
+            if (\Invertus\SaferPay\Config\SaferPayConfig::isVersion17()) {
                 $this->context->controller->registerJavascript(
                     'saved-card',
                     'modules/' . $this->name . '/views/js/front/saferpay_saved_card.js'
@@ -368,13 +346,13 @@ Thank you for your patience!');
             } else {
                 $this->context->controller->addCSS("{$this->getPathUri()}views/css/front/saferpay_checkout_16.css");
                 $this->context->controller->addJS("{$this->getPathUri()}views/js/front/saferpay_saved_card_16.js");
-                $fieldsLibrary = SaferPayConfig::FIELDS_LIBRARY;
-                $configSuffix = SaferPayConfig::getConfigSuffix();
+                $fieldsLibrary = \Invertus\SaferPay\Config\SaferPayConfig::FIELDS_LIBRARY;
+                $configSuffix = \Invertus\SaferPay\Config\SaferPayConfig::getConfigSuffix();
                 $this->context->controller->addJs(Configuration::get($fieldsLibrary . $configSuffix));
             }
 
-            /** @var SaferPayErrorDisplayService $errorDisplayService */
-            $errorDisplayService = $this->getService(SaferPayErrorDisplayService::class);
+            /** @var \Invertus\SaferPay\Service\SaferPayErrorDisplayService $errorDisplayService */
+            $errorDisplayService = $this->getService(\Invertus\SaferPay\Service\SaferPayErrorDisplayService::class);
             $errorDisplayService->showCookieError('saferpay_payment_canceled_error');
         }
     }
@@ -382,11 +360,11 @@ Thank you for your patience!');
     public function hookDisplayCustomerAccount()
     {
         $isCreditCardSaveEnabled =
-            Configuration::get(SaferPayConfig::CREDIT_CARD_SAVE);
+            Configuration::get(\Invertus\SaferPay\Config\SaferPayConfig::CREDIT_CARD_SAVE);
         if (!$isCreditCardSaveEnabled) {
             return;
         }
-        if (SaferPayConfig::isVersion17()) {
+        if (\Invertus\SaferPay\Config\SaferPayConfig::isVersion17()) {
             return $this->context->smarty->fetch(
                 $this->getLocalPath() . 'views/templates/hook/front/MyAccount.tpl'
             );
@@ -399,7 +377,7 @@ Thank you for your patience!');
 
     public function displayNavigationTop()
     {
-        if (SaferPayConfig::isVersion17()) {
+        if (\Invertus\SaferPay\Config\SaferPayConfig::isVersion17()) {
             return;
         }
 
@@ -464,27 +442,27 @@ Thank you for your patience!');
             return;
         }
 
-        /** @var SaferPayCartService $assertService */
-        $cartService = $this->getService(SaferPayCartService::class);
+        /** @var \Invertus\SaferPay\Service\SaferPayCartService $assertService */
+        $cartService = $this->getService(\Invertus\SaferPay\Service\SaferPayCartService::class);
         if (!$cartService->isCurrencyAvailable($params['cart'])) {
             return;
         }
 
-        /** @var PaymentRestrictionValidation $paymentRestrictionValidation */
-        $paymentRepository = $this->getService(SaferPayPaymentRepository::class);
+        /** @var \Invertus\SaferPay\Service\PaymentRestrictionValidation $paymentRestrictionValidation */
+        $paymentRepository = $this->getService(\Invertus\SaferPay\Repository\SaferPayPaymentRepository::class);
 
-        /** @var SaferPayObtainPaymentMethods $obtainPaymentMethods */
-        $obtainPaymentMethods = $this->getService(SaferPayObtainPaymentMethods::class);
+        /** @var \Invertus\SaferPay\Service\SaferPayObtainPaymentMethods $obtainPaymentMethods */
+        $obtainPaymentMethods = $this->getService(\Invertus\SaferPay\Service\SaferPayObtainPaymentMethods::class);
         try {
             $paymentMethods = $obtainPaymentMethods->obtainPaymentMethods();
-        } catch (SaferPayApiException $exception) {
+        } catch (\Invertus\SaferPay\Exception\Api\SaferPayApiException $exception) {
             return '';
         }
 
         $paymentOptions = [];
 
         $paymentRestrictionValidation = $this->getService(
-            PaymentRestrictionValidation::class
+            \Invertus\SaferPay\Service\PaymentRestrictionValidation::class
         );
 
         foreach ($paymentMethods as $paymentMethod) {
@@ -496,20 +474,20 @@ Thank you for your patience!');
 
             $imageUrl = ($paymentRepository->isLogoEnabledByName($paymentMethod['paymentMethod']))
                 ? $paymentMethod['logoUrl'] : '';
-            $isCreditCard = in_array($paymentMethod['paymentMethod'], SaferPayConfig::TRANSACTION_METHODS);
+            $isCreditCard = in_array($paymentMethod['paymentMethod'], \Invertus\SaferPay\Config\SaferPayConfig::TRANSACTION_METHODS);
             $isBusinessLicenseEnabled =
                 Configuration::get(
-                    SaferPayConfig::BUSINESS_LICENSE
-                    . SaferPayConfig::getConfigSuffix()
+                    \Invertus\SaferPay\Config\SaferPayConfig::BUSINESS_LICENSE
+                    . \Invertus\SaferPay\Config\SaferPayConfig::getConfigSuffix()
                 );
 
-            /** @var SaferPayCardAliasRepository $cardAliasRep */
+            /** @var \Invertus\SaferPay\Repository\SaferPayCardAliasRepository $cardAliasRep */
             $cardAliasRep = $this->getService(
-                SaferPayCardAliasRepository::class
+                \Invertus\SaferPay\Repository\SaferPayCardAliasRepository::class
             );
 
             $displayTpl = 'front/payment.tpl';
-            $isCardSaveEnabled = Configuration::get(SaferPayConfig::CREDIT_CARD_SAVE);
+            $isCardSaveEnabled = Configuration::get(\Invertus\SaferPay\Config\SaferPayConfig::CREDIT_CARD_SAVE);
             $currentDate = date('Y-m-d h:i:s');
 
             if ($isBusinessLicenseEnabled && $isCreditCard && $isCardSaveEnabled) {
@@ -536,11 +514,11 @@ Thank you for your patience!');
                 $displayTpl = 'front/payment_with_cards.tpl';
             }
 
-            /** @var PaymentRedirectionProvider $paymentRedirectionProvider */
-            $paymentRedirectionProvider = $this->getService(PaymentRedirectionProvider::class);
+            /** @var \Invertus\SaferPay\Provider\PaymentRedirectionProvider $paymentRedirectionProvider */
+            $paymentRedirectionProvider = $this->getService(\Invertus\SaferPay\Provider\PaymentRedirectionProvider::class);
 
-            /** @var PaymentTypeProvider $paymentTypeProvider */
-            $paymentTypeProvider = $this->getService(PaymentTypeProvider::class);
+            /** @var \Invertus\SaferPay\Provider\PaymentTypeProvider $paymentTypeProvider */
+            $paymentTypeProvider = $this->getService(\Invertus\SaferPay\Provider\PaymentTypeProvider::class);
 
             $this->smarty->assign(
                 [
@@ -565,13 +543,13 @@ Thank you for your patience!');
 
     public function hookPaymentReturn()
     {
-        if (SaferPayConfig::isVersion17()) {
+        if (\Invertus\SaferPay\Config\SaferPayConfig::isVersion17()) {
             return;
         }
 
-        /** @var OrderConfirmationMessageTemplate $OrderConfirmationMessageTemplate */
+        /** @var \Invertus\SaferPay\Builder\OrderConfirmationMessageTemplate $OrderConfirmationMessageTemplate */
         $OrderConfirmationMessageTemplate = $this->getService(
-            OrderConfirmationMessageTemplate::class
+            \Invertus\SaferPay\Builder\OrderConfirmationMessageTemplate::class
         );
         $OrderConfirmationMessageTemplate->setSmarty($this->context->smarty);
 
@@ -602,7 +580,7 @@ Thank you for your patience!');
         }
         $cart = new Cart($params['cart']->id);
 
-        /** @var Order $order */
+        /** @var \Order $order */
         $order = Order::getByCartId($cart->id);
 
         if (!$order) {
@@ -613,15 +591,15 @@ Thank you for your patience!');
             return true;
         }
 
-        /** @var CanSendOrderConfirmationEmail $canSendOrderConfirmationEmail */
-        $canSendOrderConfirmationEmail = $this->getService(CanSendOrderConfirmationEmail::class);
+        /** @var \Invertus\SaferPay\Core\Order\Verification\CanSendOrderConfirmationEmail $canSendOrderConfirmationEmail */
+        $canSendOrderConfirmationEmail = $this->getService(\Invertus\SaferPay\Core\Order\Verification\CanSendOrderConfirmationEmail::class);
 
         if ($params['template'] === 'order_conf') {
             return $canSendOrderConfirmationEmail->verify((int) $order->current_state);
         }
 
         if ($params['template'] === 'new_order') {
-            if ((int) Configuration::get(SaferPayConfig::SAFERPAY_SEND_NEW_ORDER_MAIL)) {
+            if ((int) Configuration::get(\Invertus\SaferPay\Config\SaferPayConfig::SAFERPAY_SEND_NEW_ORDER_MAIL)) {
                 return true;
             }
 
@@ -654,11 +632,11 @@ Thank you for your patience!');
             return;
         }
 
-        /** @var SaferPayMailService $mailService */
-        $mailService = $this->getService(SaferPayMailService::class);
+        /** @var \Invertus\SaferPay\Service\SaferPayMailService $mailService */
+        $mailService = $this->getService(\Invertus\SaferPay\Service\SaferPayMailService::class);
 
-        /** @var CanSendOrderConfirmationEmail $canSendOrderConfirmationEmail */
-        $canSendOrderConfirmationEmail = $this->getService(CanSendOrderConfirmationEmail::class);
+        /** @var \Invertus\SaferPay\Core\Order\Verification\CanSendOrderConfirmationEmail $canSendOrderConfirmationEmail */
+        $canSendOrderConfirmationEmail = $this->getService(\Invertus\SaferPay\Core\Order\Verification\CanSendOrderConfirmationEmail::class);
 
         if ($canSendOrderConfirmationEmail->verify((int) $orderStatus->id)) {
             try {
@@ -667,8 +645,8 @@ Thank you for your patience!');
                 // emailalert module sometimes throws error which leads into failed payment issue
             }
 
-            if ((int) Configuration::get(SaferPayConfig::SAFERPAY_PAYMENT_AUTHORIZED) === (int) $orderStatus->id) {
-               $mailService->sendOrderConfMail($order, (int) $orderStatus->id);
+            if ((int) \Configuration::get(\Invertus\SaferPay\Config\SaferPayConfig::SAFERPAY_PAYMENT_AUTHORIZED) === (int) $orderStatus->id) {
+                $mailService->sendOrderConfMail($order, (int) $orderStatus->id);
             }
         }
     }
@@ -683,8 +661,9 @@ Thank you for your patience!');
             $orderId = Tools::getValue('id_order');
             $order = new Order($orderId);
 
-            /** @var SaferPayOrderRepository $orderRepo */
-            $orderRepo = $this->getService(SaferPayOrderRepository::class);
+            /** @var \Invertus\SaferPay\Repository\SaferPayOrderRepository $orderRepo */
+            $orderRepo = $this->getService(\Invertus\SaferPay\Repository\SaferPayOrderRepository::class);
+
             $saferPayOrderId = $orderRepo->getIdByOrderId($orderId);
             $saferPayOrder = new SaferPayOrder($saferPayOrderId);
 
@@ -730,7 +709,7 @@ Thank you for your patience!');
         $orderId = $params['id_order'];
         $order = new Order($orderId);
         /** @var SaferPayOrderRepository $orderRepo */
-        $orderRepo = $this->getService(SaferPayOrderRepository::class);
+        $orderRepo = $this->getService(\Invertus\SaferPay\Repository\SaferPayOrderRepository::class);
         $saferPayOrderId = $orderRepo->getIdByOrderId($orderId);
         $saferPayOrder = new SaferPayOrder($saferPayOrderId);
 
@@ -742,7 +721,7 @@ Thank you for your patience!');
             return '';
         }
 
-        if (SaferPayConfig::isVersionAbove177()) {
+        if (\Invertus\SaferPay\Config\SaferPayConfig::isVersionAbove177()) {
             $action = $this->context->link->getAdminLink(
                 self::ADMIN_ORDER_CONTROLLER,
                 true,
@@ -757,9 +736,9 @@ Thank you for your patience!');
 
         $assertId = $orderRepo->getAssertIdBySaferPayOrderId($saferPayOrderId);
         $assertData = new SaferPayAssert($assertId);
-        $assertPresenter = new AssertPresenter($this);
+        $assertPresenter = new \Invertus\SaferPay\Presenter\AssertPresenter($this);
         $assertData = $assertPresenter->present($assertData);
-        $supported3DsPaymentMethods = SaferPayConfig::SUPPORTED_3DS_PAYMENT_METHODS;
+        $supported3DsPaymentMethods = \Invertus\SaferPay\Config\SaferPayConfig::SUPPORTED_3DS_PAYMENT_METHODS;
 
         // Note: This condition check or Payment method supports 3DS.
         // If payment method does not supports 3DS , when we change 'liability_shift'
@@ -772,11 +751,11 @@ Thank you for your patience!');
         $this->context->smarty->assign($assertData);
 
         $currency = new Currency($order->id_currency);
-        $adminOrderPagePresenter = new AdminOrderPagePresenter();
+        $adminOrderPagePresenter = new \Invertus\SaferPay\Presenter\AdminOrderPagePresenter();
         $orderPageData = $adminOrderPagePresenter->present(
             $saferPayOrder,
             $action,
-            SaferPayConfig::AMOUNT_MULTIPLIER_FOR_API,
+            \Invertus\SaferPay\Config\SaferPayConfig::AMOUNT_MULTIPLIER_FOR_API,
             $currency->sign
         );
 
@@ -789,7 +768,7 @@ Thank you for your patience!');
 
     public function addFlash($msg, $type)
     {
-        if (SaferPayConfig::isVersionAbove177()) {
+        if (\Invertus\SaferPay\Config\SaferPayConfig::isVersionAbove177()) {
             return $this->get('session')->getFlashBag()->add($type, $msg);
         }
 

--- a/src/Controller/AbstractSaferPayController.php
+++ b/src/Controller/AbstractSaferPayController.php
@@ -82,6 +82,10 @@ class AbstractSaferPayController extends \ModuleFrontControllerCore
             $this->lock->create($resource);
 
             if (!$this->lock->acquire()) {
+
+                if (!SaferPayConfig::isVersion17()) {
+                    return  http_response_code(409);
+                }
                 return Response::respond(
                     $this->module->l('Resource conflict', self::FILE_NAME),
                     Response::HTTP_CONFLICT
@@ -93,10 +97,18 @@ class AbstractSaferPayController extends \ModuleFrontControllerCore
             $logger->payload = $resource;
             $logger->save();
 
+            if (!SaferPayConfig::isVersion17()) {
+                return  http_response_code(500);
+            }
+
             return Response::respond(
                 $this->module->l('Internal error', self::FILE_NAME),
                 Response::HTTP_INTERNAL_SERVER_ERROR
             );
+        }
+
+        if (!SaferPayConfig::isVersion17()) {
+            return  http_response_code(200);
         }
 
         return Response::respond(

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -241,7 +241,8 @@ class Installer extends AbstractInstaller
             `captured` tinyint(1) DEFAULT 0,
             `refunded` tinyint(1) DEFAULT 0,
             `canceled` tinyint(1) DEFAULT 0,
-            `authorized` tinyint(1) DEFAULT 0
+            `authorized` tinyint(1) DEFAULT 0,
+            `pending` tinyint(1) DEFAULT 0
                 ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci'
         );
     }

--- a/src/Service/SaferPayOrderStatusService.php
+++ b/src/Service/SaferPayOrderStatusService.php
@@ -127,6 +127,12 @@ class SaferPayOrderStatusService
         $saferPayOrder->captured = 1;
 
         $saferPayOrder->update();
+
+        //NOTE: Older PS versions does not handle same state change, so we need to check if state is already set
+        if ($order->getCurrentState() === _SAFERPAY_PAYMENT_COMPLETED_) {
+            return;
+        }
+
         $order->setCurrentState(_SAFERPAY_PAYMENT_COMPLETED_);
     }
 

--- a/src/Service/TransactionFlow/SaferPayTransactionAssertion.php
+++ b/src/Service/TransactionFlow/SaferPayTransactionAssertion.php
@@ -66,9 +66,10 @@ class SaferPayTransactionAssertion
      * @return AssertBody
      * @throws \Exception
      */
-    public function assert($cartId)
+    public function assert($cartId, $update = true)
     {
         $saferPayOrder = new SaferPayOrder($this->orderRepository->getIdByCartId($cartId));
+        \PrestaShopLogger::addLog('saferpayOrderId:' . $saferPayOrder->id);
 
         $assertRequest = $this->assertRequestCreator->create($saferPayOrder->token);
         $assertResponse = $this->assertionService->assert($assertRequest, $saferPayOrder->id);
@@ -82,9 +83,12 @@ class SaferPayTransactionAssertion
             $saferPayOrder->id
         );
 
-        $saferPayOrder->transaction_id = $assertBody->getTransaction()->getId();
-        $saferPayOrder->id_cart = $cartId;
-        $saferPayOrder->update();
+        // assertion shouldn't update, this is quickfix for what seems to be a general flaw in structure
+        if ($update) {
+            $saferPayOrder->transaction_id = $assertBody->getTransaction()->getId();
+            $saferPayOrder->id_cart = $cartId;
+            $saferPayOrder->update();
+        }
 
         return $assertBody;
     }


### PR DESCRIPTION
related issues https://invertus.atlassian.net/browse/SV-15
https://invertus.atlassian.net/browse/SL-240

Move ajax getStatus action to dedicated controller;
Allow asserting transaction without updating saferpayOrder (which was the main cause causing the loop, because during getStatus it used to mess up saferPayOrder values).
This seems to prevent endless loop when waiting for return.