### PR TITLE
Fix capture and autocapture error

### DIFF
--- a/src/Entity/SaferPayAssert.php
+++ b/src/Entity/SaferPayAssert.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *NOTICE OF LICENSE
  *
@@ -55,7 +56,7 @@ class SaferPayAssert extends ObjectModel
         'primary' => 'id_saferpay_assert',
         'fields' => [
             'id_saferpay_order' => ['type' => self::TYPE_INT, 'validate' => 'isInt'],
-            'amount' => ['type' => self::TYPE_STRING, 'validate' => 'isString'],
+            'amount' => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat'],
             'status' => ['type' => self::TYPE_STRING, 'validate' => 'isString'],
             'exp_year' => ['type' => self::TYPE_INT, 'validate' => 'isInt'],
             'exp_month' => ['type' => self::TYPE_INT, 'validate' => 'isInt'],


### PR DESCRIPTION
The autocapture settings cause an error and when you try to manually capture an order it won't changes the order status (CAPTURED) and can not refund the order

With this fix we can now capture and refund