### PR TITLE
SL-270 Performance issues in BO "Payments" tab

### DIFF
--- a/controllers/admin/AdminSaferPayOfficialPaymentController.php
+++ b/controllers/admin/AdminSaferPayOfficialPaymentController.php
@@ -164,6 +164,11 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
         $fieldsForm = [];
         $fieldsForm[0]['form'] = $this->fields_form;
 
+        /** @var \Invertus\SaferPay\Service\SaferPayObtainPaymentMethods $saferPayObtainPaymentMethods */
+        $saferPayObtainPaymentMethods = $this->module->getService(SaferPayObtainPaymentMethods::class);
+
+        $paymentMethodsList = $saferPayObtainPaymentMethods->obtainPaymentMethods();
+
         foreach ($paymentMethods as $paymentMethod) {
             $isActive = $paymentRepository->isActiveByName($paymentMethod);
             $isLogoActive = $logoRepository->isActiveByName($paymentMethod);
@@ -184,7 +189,7 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
                     'paymentMethod' => $paymentMethod,
                     'countryOptions' => $this->getActiveCountriesList(),
                     'countrySelect' => $selectedCountries,
-                    'currencyOptions' => $this->getActiveCurrenciesList($paymentMethod),
+                    'currencyOptions' => $this->getActiveCurrenciesList($paymentMethod, $paymentMethodsList),
                     'currencySelect' => $selectedCurrencies,
                     'is_field_active' => $isFieldActive,
                     'supported_field_payments' => SaferPayConfig::FIELD_SUPPORTED_PAYMENT_METHODS,
@@ -219,13 +224,8 @@ class AdminSaferPayOfficialPaymentController extends ModuleAdminController
         return $countriesWithNames;
     }
 
-    public function getActiveCurrenciesList($paymentMethod)
+    public function getActiveCurrenciesList($paymentMethod, $paymentMethods)
     {
-        /** @var \Invertus\SaferPay\Service\SaferPayObtainPaymentMethods $saferPayObtainPaymentMethods */
-        $saferPayObtainPaymentMethods = $this->module->getService(SaferPayObtainPaymentMethods::class);
-
-        $paymentMethods = $saferPayObtainPaymentMethods->obtainPaymentMethods();
-
         $currencyOptions[0] = $this->l('All');
         foreach ($paymentMethods[$paymentMethod]['currencies'] as $currencyIso) {
             if (Currency::getIdByIsoCode($currencyIso)) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Release branch?           | [release-v1.2.5](https://github.com/Invertus/saferpayofficial/tree/release-v1.2.5)
| Description?      | Improved performance / loading speed on Back Office SaferPay "Payments" tab. 
| Type?             | Improvement / Performance
| PrestaShop side (FO/BO/BOTH)         | BO
| Deprecations?     | No
| How to test?      | Enable PrestaShop profiler and go to SaferPay -> Payments. Scroll down and see "Load time"
| Which issue fixed? Assigned ticket on Jira    | [SL-270](https://invertus.atlassian.net/browse/SL-270)
| Related PRs (similar)       | #192 - Performance FO in checkout

Screenshots (if available):
### Before
![image](https://github.com/user-attachments/assets/08e52780-c393-4194-924f-3acd9532600d)
### After
![image](https://github.com/user-attachments/assets/e084e50a-0c50-4ebe-a73b-bf788ae50d0d)


[SL-270]: https://invertus.atlassian.net/browse/SL-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ