### PR TITLE
Upgrade league/container to 3.x to remove abandoned dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/filesystem": "^3.4",
         "apimatic/unirest-php": "^2.3",
         "symfony/yaml": "^3.4",
-        "league/container": "2.5.0",
+        "league/container": "^3.0",
         "invertus/lock": "^1.0.0",
         "invertus/knapsack": "^10.0"
     },


### PR DESCRIPTION
Replaced abandoned container-interop/container-interop with psr/container by upgrading league/container from 2.5.0 to ^3.0 (PHP 7.1 compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Self-Checks
- [ ] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link

## Summary
<!-- Briefly explain the purpose of this PR in 1-2 sentences -->

## QA Checklist Labels
- [ ] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [ ] Technical debt? <!-- Maps to "debt" label -->
- [ ] Reusable? <!-- Maps to "reuse" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->

## QA Checklist
<!-- Provide related ticket/PR's -->
  
## Additional Context 
<!-- Provide a concise description of the changes made in this PR. -->
  
## Frontend Changes
<!-- If applicable, provide visual elements such as screenshots, GIFs, or videos to demonstrate frontend changes. -->