### PR TITLE
Fix zero amount sent to SaferPay API for products with dynamic pricing

### DIFF
--- a/src/Processor/CheckoutProcessor.php
+++ b/src/Processor/CheckoutProcessor.php
@@ -88,6 +88,8 @@ class CheckoutProcessor
             throw CouldNotProcessCheckout::failedToFindCart($data->getCartId());
         }
 
+        $cartTotal = (int) round($cart->getOrderTotal(true) * SaferPayConfig::AMOUNT_MULTIPLIER_FOR_API);
+
         if (!$data->getCreateAfterAuthorization()) {
             $this->processCreateOrder($cart, $data->getPaymentMethod());
         }
@@ -109,7 +111,8 @@ class CheckoutProcessor
                 $data->getSelectedCard(),
                 $data->getFieldToken(),
                 $data->getSuccessController(),
-                $data->getIsWebhook()
+                $data->getIsWebhook(),
+                $cartTotal
             );
         } catch (\Exception $exception) {
             throw new SaferPayApiException('Failed to initialize payment API', SaferPayApiException::INITIALIZE);
@@ -196,7 +199,8 @@ class CheckoutProcessor
         $selectedCard,
         $fieldToken,
         $successController,
-        $isWebhook
+        $isWebhook,
+        $cartTotal = null
     ) {
         $request = $this->saferPayInitialize->buildRequest(
             $paymentMethod,
@@ -204,7 +208,8 @@ class CheckoutProcessor
             $selectedCard,
             $fieldToken,
             $successController,
-            $isWebhook
+            $isWebhook,
+            $cartTotal
         );
 
         return $this->saferPayInitialize->initialize($request, $isBusinessLicense);

--- a/src/Service/Request/InitializeRequestObjectCreator.php
+++ b/src/Service/Request/InitializeRequestObjectCreator.php
@@ -57,14 +57,17 @@ class InitializeRequestObjectCreator
         $customerId,
         $isBusinessLicence,
         $alias = null,
-        $fieldToken = null
+        $fieldToken = null,
+        $cartTotal = null
     ) {
         $requestHeader = $this->requestObjectCreator->createRequestHeader();
         $terminalId = Configuration::get(SaferPayConfig::TERMINAL_ID . SaferPayConfig::getConfigSuffix());
 
-        $cartDetails = $cart->getSummaryDetails();
-        $totalPrice = $cartDetails['total_price'] * SaferPayConfig::AMOUNT_MULTIPLIER_FOR_API;
-        $totalPrice = (int) (round($totalPrice));
+        $totalPrice = $cartTotal;
+        if ($cartTotal === null) {
+            $cartDetails = $cart->getSummaryDetails();
+            $totalPrice = (int) round($cartDetails['total_price'] * SaferPayConfig::AMOUNT_MULTIPLIER_FOR_API);
+        }
         $payment = $this->requestObjectCreator->createPayment($cart, $totalPrice);
         $payer = new Payer();
 

--- a/src/Service/SaferPayInitialize.php
+++ b/src/Service/SaferPayInitialize.php
@@ -111,7 +111,8 @@ class SaferPayInitialize
         $selectedCard = -1,
         $fieldToken = null,
         $successController = null,
-        $isWebhook = 1
+        $isWebhook = 1,
+        $cartTotal = null
     ) {
         $customerEmail = $this->context->customer->email;
         $cartId = $this->context->cart->id;
@@ -155,7 +156,8 @@ class SaferPayInitialize
             $this->context->cart->id_customer,
             $isBusinessLicence,
             $alias,
-            $fieldToken
+            $fieldToken,
+            $cartTotal
         );
 
         return $initializeRequest;


### PR DESCRIPTION
## Summary

- Pre-compute cart total in `CheckoutProcessor::run()` before `processCreateOrder()` to prevent third-party modules from affecting the amount sent to SaferPay Initialize API
- When "Order creation rule" is set to "Before authorization", `validateOrder()` fires `actionValidateOrder` hook which allows third-party modules (e.g. Webkul Gift Card) to clean up dynamic pricing data, causing subsequent cart total reads to return 0
- Pass the pre-computed total through `processInitializePayment()` → `buildRequest()` → `InitializeRequestObjectCreator::create()` with backward-compatible optional parameter

## Test plan

- [ ] Verify normal products still work correctly with "Before authorization" setting
- [ ] Verify normal products still work correctly with "After authorization" setting
- [ ] Verify gift card products with dynamic pricing send the correct amount to SaferPay API
- [ ] Verify CI lint and PHPStan pass