### PR TITLE
Disable Save Changes when API credentials empty or invalid

### DIFF
--- a/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
+++ b/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
@@ -145,17 +145,23 @@ export function ApiCredentials() {
             {/* Username & Password */}
             <div className="sp-grid sp-gap-5 md:sp-grid-cols-2">
               <div className="sp-flex sp-flex-col sp-gap-2">
-                <Label htmlFor="api-username">{t('jsonApiUsername')}</Label>
+                <Label htmlFor="api-username">
+                  {t('jsonApiUsername')} <span className="sp-text-destructive" aria-hidden="true">*</span>
+                </Label>
                 <Input
                   id="api-username"
                   type="text"
                   placeholder={t('enterApiUsername', envLabel.toLowerCase())}
                   value={username}
                   onChange={(e) => setField('username', e.target.value)}
+                  required
+                  aria-required="true"
                 />
               </div>
               <div className="sp-flex sp-flex-col sp-gap-2">
-                <Label htmlFor="api-password">{t('jsonApiPassword')}</Label>
+                <Label htmlFor="api-password">
+                  {t('jsonApiPassword')} <span className="sp-text-destructive" aria-hidden="true">*</span>
+                </Label>
                 <div className="sp-relative">
                   <Input
                     id="api-password"
@@ -164,6 +170,8 @@ export function ApiCredentials() {
                     value={password}
                     onChange={(e) => setField('password', e.target.value)}
                     className="sp-pr-10"
+                    required
+                    aria-required="true"
                   />
                   <button
                     type="button"
@@ -330,7 +338,12 @@ export function ApiCredentials() {
       </Card>}
 
       <div className="sp-flex sp-justify-end">
-        <Button className="sp-min-w-[120px]" onClick={saveCredentials} disabled={saving} aria-label={saving ? t('saving') : undefined}>
+        <Button
+          className="sp-min-w-[120px]"
+          onClick={saveCredentials}
+          disabled={saving || !hasCredentials || credentialStatus === 'invalid' || credentialStatus === 'checking'}
+          aria-label={saving ? t('saving') : undefined}
+        >
           {saving ? <Loader2 className="sp-h-4 sp-w-4 sp-animate-spin" /> : t('saveChanges')}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- Disables the Save Changes button on the API Credentials tab when the active environment's username or password is empty, when the debounced credential check is still in flight, or when an inline "Invalid credentials" error is shown.
- Marks JSON API Username / JSON API Password as required (red asterisk + `aria-required="true"`) so the requirement is clear before the user clicks Save.

## Why
Surfaced during SL-351 testing (TC-351.5): submitting the form with an empty JSON API Username silently saved an empty string to `SAFERPAY_USERNAME[_TEST]` and a NULL `SAFERPAY_CUSTOMER_ID[_TEST]`, with no validation message. The terminal-fetch endpoint already shows a single inline credential error for invalid formats, so disabling the Save action avoids a duplicate toast on top of that inline message.

## Test plan
- [ ] Open Settings → API Credentials, clear JSON API Username → Save Changes is disabled
- [ ] Clear JSON API Password → Save Changes is disabled
- [ ] Enter an invalid username (e.g. `asdasasd`) with any password → inline "Invalid credentials" error shown, Save Changes disabled, no duplicate toast
- [ ] Enter valid username/password → after debounce check, Save Changes enabled, save succeeds
- [ ] Repeat all four steps in Live environment