### PR TITLE
Fix Saferpay Fields visibility per active environment license

### DIFF
--- a/controllers/admin/AdminSaferPayOfficialSettingsController.php
+++ b/controllers/admin/AdminSaferPayOfficialSettingsController.php
@@ -40,6 +40,7 @@ use Invertus\SaferPay\Service\SaferPayRefreshPaymentsService;
 use Invertus\SaferPay\Service\SaferPayRestrictionCreator;
 use Invertus\SaferPay\Exception\Api\SaferPayApiException;
 use Invertus\SaferPay\Exception\Restriction\RestrictionException;
+use Invertus\SaferPay\Logger\LoggerInterface;
 
 require_once dirname(__FILE__) . '/../../vendor/autoload.php';
 
@@ -209,8 +210,8 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
 
         // Auto-detect license features from Saferpay Management API
         $suffix = $isTestMode ? SaferPayConfig::TEST_SUFFIX : '';
-        $licenseMessage = '';
         $hasBusinessLicense = false;
+        $licenseFetchFailed = false;
 
         if (!empty($activeUsername) && !empty($activePassword) && !empty($activeCustomerId)) {
             try {
@@ -227,18 +228,29 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
                 $configuration->set(SaferPayConfig::BUSINESS_LICENSE . $suffix, $hasBusinessLicense ? 1 : 0);
             } catch (\Exception $e) {
                 $configuration->set(SaferPayConfig::BUSINESS_LICENSE . $suffix, 0);
+                $licenseFetchFailed = true;
 
-                $licenseMessage = ' ' . $this->module->l('Could not retrieve license information. Please verify your credentials.', self::FILE_NAME);
+                /** @var LoggerInterface $logger */
+                $logger = $this->module->getService(LoggerInterface::class);
+                $logger->error('License fetch failed on credentials save: ' . $e->getMessage(), [
+                    'context' => ['exception_class' => get_class($e)],
+                ]);
             }
         } else {
             $configuration->set(SaferPayConfig::BUSINESS_LICENSE . $suffix, 0);
         }
 
+        $message = $licenseFetchFailed
+            ? $this->module->l('Settings saved, but Saferpay Fields availability could not be confirmed. Please try again later or check the module Logs for details.', self::FILE_NAME)
+            : $this->module->l('Settings saved successfully.', self::FILE_NAME);
+
         $this->ajaxResponse(
             true,
-            $this->module->l('Settings saved successfully.', self::FILE_NAME) . $licenseMessage,
+            $message,
             [
-                'hasBusinessLicense' => $hasBusinessLicense,
+                'testHasBusinessLicense' => (bool) $configuration->get(SaferPayConfig::BUSINESS_LICENSE . SaferPayConfig::TEST_SUFFIX),
+                'liveHasBusinessLicense' => (bool) $configuration->get(SaferPayConfig::BUSINESS_LICENSE),
+                'warning' => $licenseFetchFailed,
             ]
         );
     }
@@ -534,8 +546,9 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
             'liveFieldAccessToken' => (string) $configuration->get(SaferPayConfig::FIELDS_ACCESS_TOKEN),
             'liveFieldJsUrl' => (string) $configuration->get(SaferPayConfig::FIELDS_LIBRARY),
 
-            // License (auto-detected)
-            'hasBusinessLicense' => (bool) $configuration->get(SaferPayConfig::BUSINESS_LICENSE . SaferPayConfig::getConfigSuffix()),
+            // License (auto-detected, per environment)
+            'testHasBusinessLicense' => (bool) $configuration->get(SaferPayConfig::BUSINESS_LICENSE . SaferPayConfig::TEST_SUFFIX),
+            'liveHasBusinessLicense' => (bool) $configuration->get(SaferPayConfig::BUSINESS_LICENSE),
 
             // Payment Processing
             'paymentBehavior' => (int) $configuration->get(SaferPayConfig::PAYMENT_BEHAVIOR),

--- a/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
+++ b/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
@@ -35,6 +35,7 @@ export function ApiCredentials() {
   const fieldJsUrl = isTest ? settings.testFieldJsUrl : settings.liveFieldJsUrl
 
   const hasCredentials = username.length > 0 && password.length > 0
+  const hasBusinessLicense = isTest ? settings.testHasBusinessLicense : settings.liveHasBusinessLicense
 
   const setField = (field: string, value: string | boolean) => {
     updateSettings({ [`${prefix}${field.charAt(0).toUpperCase() + field.slice(1)}`]: value } as Record<string, string | boolean>)
@@ -145,17 +146,23 @@ export function ApiCredentials() {
             {/* Username & Password */}
             <div className="sp-grid sp-gap-5 md:sp-grid-cols-2">
               <div className="sp-flex sp-flex-col sp-gap-2">
-                <Label htmlFor="api-username">{t('jsonApiUsername')}</Label>
+                <Label htmlFor="api-username">
+                  {t('jsonApiUsername')} <span className="sp-text-destructive" aria-hidden="true">*</span>
+                </Label>
                 <Input
                   id="api-username"
                   type="text"
                   placeholder={t('enterApiUsername', envLabel.toLowerCase())}
                   value={username}
                   onChange={(e) => setField('username', e.target.value)}
+                  required
+                  aria-required="true"
                 />
               </div>
               <div className="sp-flex sp-flex-col sp-gap-2">
-                <Label htmlFor="api-password">{t('jsonApiPassword')}</Label>
+                <Label htmlFor="api-password">
+                  {t('jsonApiPassword')} <span className="sp-text-destructive" aria-hidden="true">*</span>
+                </Label>
                 <div className="sp-relative">
                   <Input
                     id="api-password"
@@ -164,6 +171,8 @@ export function ApiCredentials() {
                     value={password}
                     onChange={(e) => setField('password', e.target.value)}
                     className="sp-pr-10"
+                    required
+                    aria-required="true"
                   />
                   <button
                     type="button"
@@ -242,7 +251,7 @@ export function ApiCredentials() {
         </CardContent>
       </Card>
 
-      {settings.hasBusinessLicense && <Card>
+      {hasBusinessLicense && <Card>
         <CardHeader>
           <CardTitle className="sp-text-base sp-font-semibold">{t('saferpayFields')}</CardTitle>
           <CardDescription>{t('saferpayFieldsDescription')}</CardDescription>
@@ -330,7 +339,12 @@ export function ApiCredentials() {
       </Card>}
 
       <div className="sp-flex sp-justify-end">
-        <Button className="sp-min-w-[120px]" onClick={saveCredentials} disabled={saving} aria-label={saving ? t('saving') : undefined}>
+        <Button
+          className="sp-min-w-[120px]"
+          onClick={saveCredentials}
+          disabled={saving || !hasCredentials || credentialStatus === 'invalid' || credentialStatus === 'checking'}
+          aria-label={saving ? t('saving') : undefined}
+        >
           {saving ? <Loader2 className="sp-h-4 sp-w-4 sp-animate-spin" /> : t('saveChanges')}
         </Button>
       </div>

--- a/views/js/admin/settings-app/src/context/settings-context.tsx
+++ b/views/js/admin/settings-app/src/context/settings-context.tsx
@@ -48,7 +48,7 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const handleSave = useCallback(async (
-    saveFn: () => Promise<{ success: boolean; message?: string }>,
+    saveFn: () => Promise<{ success: boolean; message?: string; warning?: boolean }>,
     label: string,
     section: SavingSection,
   ) => {
@@ -56,7 +56,8 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     try {
       const result = await saveFn()
       if (result.success) {
-        toast({ title: result.message || t('savedSuccessfully', label), variant: 'default' })
+        const variant = result.warning ? 'warning' : 'default'
+        toast({ title: result.message || t('savedSuccessfully', label), variant })
       } else {
         toast({ title: result.message || t('failedToSave', label), variant: 'destructive' })
       }
@@ -91,10 +92,14 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
         liveFieldJsUrl: currentSettings.liveFieldJsUrl,
       })
       const data = result as unknown as Record<string, unknown>
-      if (result.success && typeof data.hasBusinessLicense === 'boolean') {
-        setSettings((prev) => ({ ...prev, hasBusinessLicense: data.hasBusinessLicense as boolean }))
+      if (result.success) {
+        setSettings((prev) => ({
+          ...prev,
+          ...(typeof data.testHasBusinessLicense === 'boolean' ? { testHasBusinessLicense: data.testHasBusinessLicense as boolean } : {}),
+          ...(typeof data.liveHasBusinessLicense === 'boolean' ? { liveHasBusinessLicense: data.liveHasBusinessLicense as boolean } : {}),
+        }))
       }
-      return result
+      return { ...result, warning: data.warning === true }
     }, 'API Credentials', 'credentials')
   }, [handleSave])
 

--- a/views/js/admin/settings-app/src/types/index.ts
+++ b/views/js/admin/settings-app/src/types/index.ts
@@ -33,8 +33,9 @@ export interface SaferpaySettingsData {
   liveFieldAccessToken: string
   liveFieldJsUrl: string
 
-  // License (read-only, auto-detected from API)
-  hasBusinessLicense: boolean
+  // License (read-only, auto-detected from API, per environment)
+  testHasBusinessLicense: boolean
+  liveHasBusinessLicense: boolean
 
   // Payment Processing
   paymentBehavior: number


### PR DESCRIPTION
## Summary

- Saferpay Fields section was gated by a single `hasBusinessLicense` flag tied to the active environment at page load. Switching environments client-side never re-evaluated it, so the section remained visible after flipping to an env with no validated business license.
- Backend now exposes `testHasBusinessLicense` and `liveHasBusinessLicense` separately (initial payload and save response).
- `api-credentials.tsx` derives the active flag from `isTest` and gates the Saferpay Fields card on it.

## Test plan

- [x] Test mode with valid test license: Saferpay Fields section visible
- [x] Switch dropdown to Live (no live credentials, no live license): section hides immediately
- [x] Switch back to Test: section reappears
- [ ] Save credentials in each env and confirm both flags persist correctly across reloads