### PR TITLE
fix: break out of SaferPay iframe on payment status redirect

### DIFF
--- a/views/templates/front/saferpay_wait.tpl
+++ b/views/templates/front/saferpay_wait.tpl
@@ -99,7 +99,7 @@
                 try {
                     var data = JSON.parse(request.responseText);
                     if (data.isFinished && data.href) {
-                        window.location.href = data.href;
+                        (window.top || window).location.href = data.href;
                         return;
                     }
                 } catch (e) {

--- a/views/templates/front/saferpay_wait.tpl
+++ b/views/templates/front/saferpay_wait.tpl
@@ -99,7 +99,11 @@
                 try {
                     var data = JSON.parse(request.responseText);
                     if (data.isFinished && data.href) {
-                        (window.top || window).location.href = data.href;
+                        try {
+                            (window.top || window).location.replace(data.href);
+                        } catch (e) {
+                            window.location.replace(data.href);
+                        }
                         return;
                     }
                 } catch (e) {


### PR DESCRIPTION
## Summary
- The polling script in `views/templates/front/saferpay_wait.tpl` navigated the iframe itself via `window.location.href`, leaving the parent window stuck on `/module/saferpayofficial/iframe?...` while the cart or order-confirmation page rendered nested inside the iframe.
- Switched the redirect to `(window.top || window).location.href` so the top window navigates, matching the iframe-breakout pattern already used in `views/js/front/saferpay_iframe.js`.

## Test plan
- [x] Cancel path (3DS auth without liability shift, `paymentBehaviorWithout3D = Cancel`): browser lands at top-level `/gb/cart?action=show` with the standard "We couldn't authorize your payment" notice (no nested chrome).
- [x] Success path (Capture behavior, same card): browser lands at top-level `/gb/order-confirmation?id_cart=...&id_order=...&key=...`; `ps_saferpay_order` shows `authorized=1, captured=1`; PS order state 21 (Payment completed by Saferpay).
- [x] Verified on PS 8.2.3 / PHP 8.1 against the SL-346 redesign branch.