### PR TITLE
BUGFIX: clarify Hosted field style info banner to mention Custom form requirement

### DIFF
--- a/src/Service/SettingsTranslationService.php
+++ b/src/Service/SettingsTranslationService.php
@@ -229,7 +229,7 @@ class SettingsTranslationService
             'configName' => $this->module->l('Payment Page configurations name', self::FILE_NAME),
             'enterConfigName' => $this->module->l('Enter configuration name', self::FILE_NAME),
             'configNameDescription' => html_entity_decode($this->module->l('Name of the Payment Page Configuration created in Saferpay Backoffice (Settings > Payment Page Configuration). Max 20 characters. Allowed: letters, numbers, dots, colons, hyphens, underscores.', self::FILE_NAME), ENT_QUOTES, 'UTF-8'),
-            'hostedFieldInfo' => $this->module->l('Choose which hosted field will be displayed on payment option selection with supported payment methods.', self::FILE_NAME),
+            'hostedFieldInfo' => html_entity_decode($this->module->l('This style applies only to payment methods with "Custom form" enabled in the Payment Methods list. Methods without Custom form or paid with saved cards use the Saferpay-hosted payment page, whose appearance is controlled by "Payment Page configurations name".', self::FILE_NAME), ENT_QUOTES, 'UTF-8'),
             'hostedFieldStyle' => $this->module->l('Hosted field style', self::FILE_NAME),
             'hostedFieldStyleDescription' => $this->module->l('Select the card input form layout for the payment page.', self::FILE_NAME),
             'classicLayout' => $this->module->l('Classic Layout', self::FILE_NAME),


### PR DESCRIPTION
## Summary
- "Hosted field style" (Classic / Labeled / Inline with Card) only affects checkouts that go through the module's own hosted fields flow — i.e. payment methods with **Custom form enabled**. Saved-card flow and methods without Custom form use the Saferpay-hosted Payment Page, whose appearance is controlled by **"Payment Page configurations name"** (`ConfigSet`).
- The previous info banner text ("Choose which hosted field will be displayed on payment option selection with supported payment methods.") was generic and led merchants to expect the style to apply universally.

## Changes
- `src/Service/SettingsTranslationService.php`: rewrite `hostedFieldInfo` to explicitly state the Custom form prerequisite and point users to "Payment Page configurations name" for the Saferpay-hosted page styling. Wrapped in `html_entity_decode(..., ENT_QUOTES, 'UTF-8')` so quotes render correctly (same pattern already used for `configNameDescription`).

No FE/build changes — same translation key, same banner component.

## Test plan
- [x] Open module settings → General → Styling section.
- [x] Verify the info banner shows the new wording with proper quotes (not `&quot;`).
- [ ] Verify all supported PS versions (1.7.x, 8.x, 9.x) render the banner correctly.