### PR TITLE
BUGFIX: validate Merchant Emails field on save

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -199,3 +199,4 @@
 - Added feature to group card payment methods into unified "Card" payment method
 - Fixed issue when newly enabled payment methods did not appear in checkout because default "all countries/currencies" restriction was not created on save
 - Fixed issue when payment method country/currency dropdowns showed "0" instead of indicating that all countries/currencies are allowed
+- BO : Added validation for Merchant Emails field (frontend + backend) to prevent saving invalid addresses

--- a/controllers/admin/AdminSaferPayOfficialSettingsController.php
+++ b/controllers/admin/AdminSaferPayOfficialSettingsController.php
@@ -179,6 +179,17 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
             }
         }
 
+        $testMerchantEmails = $this->getStringValue($data, 'testMerchantEmails');
+        $liveMerchantEmails = $this->getStringValue($data, 'liveMerchantEmails');
+        $invalidEmail = $this->findInvalidEmail($testMerchantEmails) ?: $this->findInvalidEmail($liveMerchantEmails);
+        if ($invalidEmail !== null) {
+            $this->ajaxResponse(false, sprintf(
+                $this->module->l('Invalid merchant email address: %s', self::FILE_NAME),
+                $invalidEmail
+            ));
+            return;
+        }
+
         // Credentials validated — now save
         $configuration->set(SaferPayConfig::TEST_MODE, $isTestMode ? 1 : 0);
 
@@ -791,5 +802,25 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
     private function getIntValue($data, $key)
     {
         return isset($data[$key]) ? (int) $data[$key] : 0;
+    }
+
+    /**
+     * Returns the first invalid email in a comma-separated list, or null if all are valid.
+     */
+    private function findInvalidEmail($emails)
+    {
+        if ($emails === '') {
+            return null;
+        }
+        foreach (explode(',', $emails) as $email) {
+            $email = trim($email);
+            if ($email === '') {
+                continue;
+            }
+            if (!\Validate::isEmail($email)) {
+                return $email;
+            }
+        }
+        return null;
     }
 }

--- a/src/Service/SettingsTranslationService.php
+++ b/src/Service/SettingsTranslationService.php
@@ -122,6 +122,7 @@ class SettingsTranslationService
             'merchantEmails' => $this->module->l('Merchant Emails', self::FILE_NAME),
             'enterMerchantEmails' => $this->module->l('Enter merchant email addresses (comma-separated)', self::FILE_NAME),
             'separateEmails' => $this->module->l('These email addresses receive payment notification emails directly from SaferPay. Separate multiple email addresses with commas.', self::FILE_NAME),
+            'invalidMerchantEmails' => $this->module->l('Invalid email address', self::FILE_NAME),
             'saferpayFields' => $this->module->l('Saferpay Fields', self::FILE_NAME),
             'saferpayFieldsDescription' => $this->module->l('Configure Saferpay Fields for inline payment form integration.', self::FILE_NAME),
             'fieldAccessTokenInfo' => $this->module->l('Saferpay Field Access Token can be found in Saferpay Backoffice, navigate to', self::FILE_NAME),

--- a/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
+++ b/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
@@ -37,6 +37,13 @@ export function ApiCredentials() {
   const hasCredentials = username.length > 0 && password.length > 0
   const hasBusinessLicense = isTest ? settings.testHasBusinessLicense : settings.liveHasBusinessLicense
 
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  const invalidEmails = merchantEmails
+    .split(',')
+    .map(e => e.trim())
+    .filter(e => e.length > 0 && !EMAIL_RE.test(e))
+  const merchantEmailsInvalid = invalidEmails.length > 0
+
   const setField = (field: string, value: string | boolean) => {
     updateSettings({ [`${prefix}${field.charAt(0).toUpperCase() + field.slice(1)}`]: value } as Record<string, string | boolean>)
   }
@@ -242,7 +249,14 @@ export function ApiCredentials() {
                 placeholder={t('enterMerchantEmails')}
                 value={merchantEmails}
                 onChange={(e) => setField('merchantEmails', e.target.value)}
+                aria-invalid={merchantEmailsInvalid}
+                className={merchantEmailsInvalid ? 'sp-border-destructive focus-visible:sp-ring-destructive' : ''}
               />
+              {merchantEmailsInvalid && (
+                <p className="sp-text-xs sp-text-destructive">
+                  {t('invalidMerchantEmails')}: {invalidEmails.join(', ')}
+                </p>
+              )}
               <p className="sp-text-xs sp-text-muted-foreground">
                 {t('separateEmails')}
               </p>
@@ -342,7 +356,7 @@ export function ApiCredentials() {
         <Button
           className="sp-min-w-[120px]"
           onClick={saveCredentials}
-          disabled={saving || !hasCredentials || credentialStatus === 'invalid' || credentialStatus === 'checking'}
+          disabled={saving || !hasCredentials || credentialStatus === 'invalid' || credentialStatus === 'checking' || merchantEmailsInvalid}
           aria-label={saving ? t('saving') : undefined}
         >
           {saving ? <Loader2 className="sp-h-4 sp-w-4 sp-animate-spin" /> : t('saveChanges')}


### PR DESCRIPTION
## Summary
- **Issue:** Merchant Emails input accepted any string (e.g. `demo@p§1312312EWRWrestashop.com`) and the controller persisted it verbatim. Notifications would silently bounce / never be sent.
- **Frontend** (`api-credentials.tsx`): on every change, split by `,`, trim, validate each part against an email regex. When any entry is invalid → input shows red border + inline error listing the bad values; Save button disabled.
- **Backend** (`AdminSaferPayOfficialSettingsController::ajaxProcessSaveCredentials`): new `findInvalidEmail()` helper walks both `testMerchantEmails` and `liveMerchantEmails` and rejects the save with a clear message if `Validate::isEmail()` fails. Guards against curl / devtools bypass.
- Translation key `invalidMerchantEmails` added.
- Changelog entry added under `[2.0.2]`.

## Test plan
- [x] Frontend: typing `foo@bar.com, not-an-email` shows red border + "Invalid email address: not-an-email"; Save disabled.
- [x] Frontend: clearing the invalid part restores Save.
- [x] Backend: direct POST to `?action=saveCredentials` with `testMerchantEmails="demo@p§1.com"` returns `{"success":false,"message":"Invalid merchant email address: demo@p§1.com"}`; DB unchanged.
- [x] Backend: valid comma-separated list (`a@x.com, b@y.com`) saves successfully.
- [ ] Visual: red border + error message render under the input on the Settings → API Credentials tab.