### PR TITLE
SL-378 Fix API password corruption and plaintext exposure on settings save

### DIFF
--- a/controllers/admin/AdminSaferPayOfficialSettingsController.php
+++ b/controllers/admin/AdminSaferPayOfficialSettingsController.php
@@ -56,6 +56,9 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
 
     public function postProcess()
     {
+        $this->keepExistingPasswordWhenSubmittedEmpty(SaferPayConfig::PASSWORD);
+        $this->keepExistingPasswordWhenSubmittedEmpty(SaferPayConfig::PASSWORD . SaferPayConfig::TEST_SUFFIX);
+
         parent::postProcess();
 
         /** @var Configuration $configuration */
@@ -80,6 +83,15 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
         $this->validateTerminalId();
 
         return true;
+    }
+
+    private function keepExistingPasswordWhenSubmittedEmpty($key)
+    {
+        if (!isset($_POST[$key]) || $_POST[$key] !== '') {
+            return;
+        }
+
+        $_POST[$key] = \Configuration::get($key);
     }
 
     private function validateTerminalId()
@@ -489,7 +501,10 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
                     'title' => $this->module->l('JSON API Password'),
                     'type' => 'password_input',
                     'class' => 'fixed-width-xl',
-                    'value' => \Configuration::get(SaferPayConfig::PASSWORD . SaferPayConfig::TEST_SUFFIX),
+                    'autocomplete' => false,
+                    'placeholder' => \Configuration::get(SaferPayConfig::PASSWORD . SaferPayConfig::TEST_SUFFIX)
+                        ? $this->module->l('Leave empty to keep the saved password')
+                        : '',
                 ],
                 SaferPayConfig::CUSTOMER_ID . SaferPayConfig::TEST_SUFFIX => [
                     'title' => $this->module->l('Customer ID'),
@@ -557,7 +572,10 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
                     'title' => $this->module->l('JSON API Password'),
                     'type' => 'password_input',
                     'class' => 'fixed-width-xl',
-                    'value' => \Configuration::get(SaferPayConfig::PASSWORD),
+                    'autocomplete' => false,
+                    'placeholder' => \Configuration::get(SaferPayConfig::PASSWORD)
+                        ? $this->module->l('Leave empty to keep the saved password')
+                        : '',
                 ],
                 SaferPayConfig::CUSTOMER_ID => [
                     'title' => $this->module->l('Customer ID'),

--- a/views/templates/admin/field-option-settings/helpers/options/options.tpl
+++ b/views/templates/admin/field-option-settings/helpers/options/options.tpl
@@ -31,7 +31,8 @@
                     class="{if isset($field['class'])}{$field['class']|escape:'htmlall':'UTF-8'}{/if}"
                     size="{if isset($field['size'])}{$field['size']|intval}{else}5{/if}"
                     name="{$key|escape:'htmlall':'UTF-8'}"
-                    value="{$field['value']|escape:'htmlall':'UTF-8'}"
+                    value=""
+                    {if isset($field['placeholder']) && $field['placeholder']} placeholder="{$field['placeholder']|escape:'htmlall':'UTF-8'}"{/if}
                     {if isset($field['autocomplete']) && !$field['autocomplete']} autocomplete="off"{/if} />
         </div>
     {/if}


### PR DESCRIPTION
## Problem
On the settings page (2.0.3), a saved JSON API password containing `&`, `<`, `>` or `"` gets silently corrupted every time the settings are saved without re-typing it. The `password_input` template escapes the pre-filled value (regression from `f7adabca`), and on the next save that escaped value is submitted back and double-encoded. The corrupted password then fails auth with a 401 "Failed to fetch terminals", with no visible error in the back office. Purely alphanumeric passwords are unaffected.

Separately, the stored password was rendered in clear text in the page source.

## Fix
- Stop pre-filling the password into the `value` attribute (template renders `value=""`).
- Keep the stored password when the field is submitted empty (`keepExistingPasswordWhenSubmittedEmpty`).
- Add `autocomplete="off"` and a "leave empty to keep the saved password" hint.

## Verification (PS 9.1.3, module 2.0.3)
- Save without touching the password: stored value preserved (before: `Test&Pass&12` corrupted to `Test&amp;Pass&12`).
- Type a new `&`-password: stored exactly as entered.
- Password no longer present in page source.
- Passes the PrestaShop module validator (no unescaped output); PHP 7.1 compatible.

## Notes
Not yet confirmed as the cause of the current merchant 401 report - that is being verified separately on the merchant environment. This is a valid fix regardless.

Ticket: https://invertus.atlassian.net/browse/SL-378