### PR TITLE
Fix misleading payment methods warning in settings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -214,3 +214,5 @@
 - BO/FO : Accessibility improvements for EAA / WCAG 2.1 AA compliance
 - Added configurable payment description and order reference on payment page
 - API update to V1.50: added WERO and GIFTCARD payment methods, removed deprecated GIROPAY/PAYDIREKT/SOFORT
+- BO : Fixed issue when a freshly installed module logged an account error before any API credentials were entered
+- BO : Fixed issue when the "Could not reach your Saferpay account" warning kept showing after payment methods had loaded successfully

--- a/controllers/admin/AdminSaferPayOfficialSettingsController.php
+++ b/controllers/admin/AdminSaferPayOfficialSettingsController.php
@@ -566,6 +566,9 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
         /** @var SaferPayConfiguration $configuration */
         $configuration = $this->module->getService(SaferPayConfiguration::class);
 
+        // Resolved before the payload is built because it sets $paymentMethodsFetchFailed.
+        $paymentMethodsData = $this->getPaymentMethodsData();
+
         $data = [
             // Environment
             'testMode' => (bool) $configuration->get(SaferPayConfig::TEST_MODE),
@@ -615,7 +618,7 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
             'orderStates' => $this->getOrderStates(),
             'countries' => $this->getCountries(),
             'currencies' => $this->getCurrencies(),
-            'paymentMethods' => $this->getPaymentMethodsData(),
+            'paymentMethods' => $paymentMethodsData,
             'paymentMethodsFetchFailed' => $this->paymentMethodsFetchFailed,
 
             // Endpoints
@@ -698,14 +701,21 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
         /** @var SaferPayPaymentRepository $paymentRepository */
         $paymentRepository = $this->module->getService(SaferPayPaymentRepository::class);
 
+        // A fresh install has no credentials yet, so calling the account would fail and
+        // write a misleading error to the merchant's log. Skip the account entirely until
+        // the credentials needed to build the request are present.
+        $hasCredentials = $this->hasApiCredentials();
+
         try {
             // Re-read the account and reconcile the stored list when the Payment Methods
             // settings open, so methods added/removed on the Saferpay account are reflected
             // (and persisted for the front office) without requiring a Save click. Enabled
             // flags are preserved by the refresh; newly added methods default to disabled.
-            /** @var SaferPayRefreshPaymentsService $refreshPaymentsService */
-            $refreshPaymentsService = $this->module->getService(SaferPayRefreshPaymentsService::class);
-            $refreshPaymentsService->refreshPayments();
+            if ($hasCredentials) {
+                /** @var SaferPayRefreshPaymentsService $refreshPaymentsService */
+                $refreshPaymentsService = $this->module->getService(SaferPayRefreshPaymentsService::class);
+                $refreshPaymentsService->refreshPayments();
+            }
 
             // The refresh persists the account's methods, so read them back from storage
             // instead of calling the API a second time.
@@ -713,7 +723,7 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
 
             // refreshPayments() is a no-op when nothing is active yet (e.g. a fresh setup),
             // so fall back to the live account list to still surface newly available methods.
-            if (empty($paymentMethods)) {
+            if (empty($paymentMethods) && $hasCredentials) {
                 /** @var SaferPayObtainPaymentMethods $obtainMethods */
                 $obtainMethods = $this->module->getService(SaferPayObtainPaymentMethods::class);
                 $paymentMethods = $obtainMethods->obtainPaymentMethodsNamesAsArray();
@@ -766,6 +776,31 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
         }
 
         return $result;
+    }
+
+    /**
+     * Whether every credential the payment methods request is built from is configured
+     * for the active environment.
+     *
+     * @return bool
+     */
+    private function hasApiCredentials()
+    {
+        $suffix = SaferPayConfig::getConfigSuffix();
+        $required = [
+            SaferPayConfig::USERNAME,
+            SaferPayConfig::PASSWORD,
+            SaferPayConfig::CUSTOMER_ID,
+            SaferPayConfig::TERMINAL_ID,
+        ];
+
+        foreach ($required as $key) {
+            if (!Configuration::get($key . $suffix)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/views/js/admin/settings-app/src/components/settings/payment-methods.tsx
+++ b/views/js/admin/settings-app/src/components/settings/payment-methods.tsx
@@ -154,7 +154,14 @@ export function PaymentMethods() {
   // The account check runs while the page bootstraps, so a failure arrives via
   // the initial settings data rather than a refresh response.
   useEffect(() => {
-    if (settings.paymentMethodsFetchFailed && !fetchFailedToastShown) {
+    // Clearing the latch keeps a later, genuine failure from being swallowed.
+    if (!settings.paymentMethodsFetchFailed) {
+      fetchFailedToastShown = false
+
+      return
+    }
+
+    if (!fetchFailedToastShown) {
       fetchFailedToastShown = true
       toast({ title: t('paymentMethodsUnreachable'), variant: 'warning' })
     }

--- a/views/js/admin/settings-app/src/context/settings-context.tsx
+++ b/views/js/admin/settings-app/src/context/settings-context.tsx
@@ -150,8 +150,17 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
       if (result.success && Array.isArray(result.data?.paymentMethods)) {
         setPaymentMethods(result.data.paymentMethods as PaymentMethodData[])
       }
-      if (result.data?.paymentMethodsFetchFailed === true) {
-        toast({ title: t('paymentMethodsUnreachable'), variant: 'warning' })
+
+      // Mirror the refreshed outcome onto the bootstrap flag, otherwise a failure from
+      // page load keeps warning after a later refresh has already succeeded. Only a
+      // response that actually reports the flag may clear it.
+      if (result.data && 'paymentMethodsFetchFailed' in result.data) {
+        const fetchFailed = result.data.paymentMethodsFetchFailed === true
+        setSettings((prev) => ({ ...prev, paymentMethodsFetchFailed: fetchFailed }))
+
+        if (fetchFailed) {
+          toast({ title: t('paymentMethodsUnreachable'), variant: 'warning' })
+        }
       }
     } catch {
       toast({ title: t('errorRefreshingPaymentMethods'), variant: 'destructive' })


### PR DESCRIPTION
## Problem

Reported from a fresh install: the Logs tab showed an `Error` entry about the Saferpay account, yet the payment methods grid was populated. Two separate defects were behind it.

**1. The account was called before any credentials existed.**
`getPaymentMethodsData()` called `refreshPayments()` unconditionally when the Payment Methods settings opened. On a fresh install there are no credentials, so the request 404s and writes a severity-3 error to the merchant's log before they have configured anything.

**2. The failure flag was never cleared.**
`paymentMethodsFetchFailed` arrives with the bootstrap payload. `refreshPaymentMethods()` updated the methods list but never touched the flag, so a failure from page load kept the "Could not reach your Saferpay account" warning on screen after a later refresh had already succeeded and filled the grid. That is exactly the contradiction that was reported.

## Changes

- `AdminSaferPayOfficialSettingsController` - new `hasApiCredentials()` guard; the account is only contacted once username, password, customer ID and terminal ID are all set for the active environment. It reads the same four keys with the same suffix that `ObtainPaymentMethodsObjectCreator` builds the request from, so the guard cannot disagree with the request.
- `settings-context.tsx` - `refreshPaymentMethods()` now mirrors the refreshed outcome onto the flag, so a resolved failure stops warning. Only a response that actually reports the flag may clear it.
- `payment-methods.tsx` - the module-level toast latch resets when the flag clears, so a later genuine failure is not swallowed. The latch stays module-level on purpose, so tab switches do not re-toast.

Stored configuration is never cleared by any of this: `refreshPayments()` throws before it truncates, so a failed refresh cannot wipe the merchant's enabled methods.

## Verification

Tested on PrestaShop 9.1.4, TEST environment, against the real sandbox account.

| Case | Setup | Result |
|---|---|---|
| 1 | Fresh install, no credentials | 0 log rows written (was severity 1 + severity 3), no warning, page renders |
| 2 | Valid TEST credentials | 24 methods load, credentials verify, terminal dropdown populates, 0 severity-3 rows |
| 3 | Wrong password | Warning still fires - not swallowed |
| 4 | Load with failure, then fix credentials and reopen the tab | Grid populates and the warning is gone - the reported bug |

Also checked: `php -l` clean, php-cs-fixer clean, `tsc --noEmit` clean, `SaferPayRefreshPaymentsServiceTest` passes.

Two things worth knowing:

- The latch-reset in `payment-methods.tsx` has no reachable path in a single page session, because the only refresh trigger is the automatic one that fires when the list is empty. It is defensive, not something case 4 exercised.
- `BasePaymentRestrictionValidationTest` errors in the unit suite, but it does so on an untouched branch too: `webmozart/assert` in `vendor/` needs PHP 8 union types while phpunit 7.5 caps at PHP 8.0, so the suite cannot run on any PHP available here. Unrelated to this change.

## Notes

Branched from `feature/react-admin-settings` rather than `master`, because the React settings app this fixes only exists on that branch. Targets `feature/react-admin-settings` so PR #332 is not disturbed.

No Jira ticket was supplied for this one, so the branch uses the `BUGFIX/` prefix.
