### PR TITLE
INTERNAL Fix CI pipeline: run lint and phpstan without the private workspace repo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,8 +18,9 @@ jobs:
     env:
       # Change these values depending on project.
       ps-module-name: saferpayofficial
-      project-workspace-dir: ${{ github.workspace }}/../workspace
+      container-name: ps-lint
     strategy:
+      fail-fast: false
       matrix:
         PS: [ 1.7.8-7.4 ]
         testsuite: [ lint, phpstan ]
@@ -33,59 +34,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set Swap Space
-        uses: Invertus/set-swap-space@master
-        with:
-          swap-size-gb: 10
-
-      - name: Set up workspace
-        shell: bash
+      # lint and phpstan need the PrestaShop sources on disk and the matching PHP
+      # version, but no running shop, so the public image is started idle with the
+      # checked-out module mounted in place.
+      - name: Start PrestaShop container
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${{ secrets.PS_MODULE_WORKSPACE_SAFERPAY_PRIVATE_KEY }}"
-          git clone git@github.com:Invertus/ps-module-workspace.git ${{ env.project-workspace-dir }}
-          cd ${{ env.project-workspace-dir }}
-          sed 's/PROJECT_NAME=.*/PROJECT_NAME=${{ env.ps-module-name }}/g' < .env.dist |
-          sed 's/PS_VERSION_TAG=.*/PS_VERSION_TAG=${{ matrix.PS }}/g' > .env
-          make create-modules-dir
-          cp -R ${{ github.workspace }} ${{ env.project-workspace-dir }}/prestashop/${{ matrix.PS }}/modules/${{ env.ps-module-name }}
+          docker run -d --name ${{ env.container-name }} \
+            -v ${{ github.workspace }}:/var/www/html/modules/${{ env.ps-module-name }} \
+            --entrypoint tail prestashop/prestashop:${{ matrix.PS }} -f /dev/null
 
-      - name: Run PrestaShop
+      - name: Install git and composer in container
         run: |
-          (cd ${{ env.project-workspace-dir }} && docker compose up -d)
-
-      - name: Healthcheck
-        run: |
-          timeout 120s sh -c 'until docker ps | grep ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} | grep -q "(healthy)"; do echo "Waiting for container to be healthy..."; sleep 1; done'
-
-      - name: Cache composer folder
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.project-workspace-dir }}/prestashop/${{ matrix.PS }}/modules/${{ env.ps-module-name }}/vendor
-          key: ${{ github.sha }}
-
-      - name: Install git
-        run: |
-          docker exec -i ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} bash -c "apt update && apt install -y git"
-
-      - name: Remove old module
-        run: docker exec -i ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} bash -c "cd /var/www/html/modules && rm -rf ${{ env.ps-module-name }}"
-
-      - name: Install module
-        run: docker exec -i ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} bash -c "cd /var/www/html/modules && git clone https://github.com/Invertus/${{ env.ps-module-name }}"
-
-      - name: Switch to the correct branch
-        run: |
-          docker exec -i ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} bash -c "cd /var/www/html/modules/${{ env.ps-module-name }} && git fetch origin && git checkout ${{ github.head_ref || github.ref_name }}"
+          docker exec -i ${{ env.container-name }} bash -c "apt-get update -qq && apt-get install -y -qq git"
+          docker exec -i ${{ env.container-name }} bash -c "php -r \"copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');\" && php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet && composer --version"
 
       - name: Install composer dependencies
-        run: docker exec -i ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} bash -c "cd /var/www/html/modules/${{ env.ps-module-name }} && composer install"
+        run: docker exec -i ${{ env.container-name }} bash -c "cd /var/www/html/modules/${{ env.ps-module-name }} && composer install --no-interaction"
 
       - name: PHP version
-        run: docker exec -i ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} bash -c "php -v"
+        run: docker exec -i ${{ env.container-name }} bash -c "php -v"
 
       - name: Run ${{ matrix.testsuite }} tests
-        run: docker exec -i ${{ env.ps-module-name }}-ps-prestashop-${{ matrix.PS }} bash -c "cd /var/www/html/modules/${{ env.ps-module-name }} && make ci-${{ matrix.testsuite }} ps_version_tag=${{ matrix.PS }}"
+        run: docker exec -i ${{ env.container-name }} bash -c "cd /var/www/html/modules/${{ env.ps-module-name }} && make ci-${{ matrix.testsuite }} ps_version_tag=${{ matrix.PS }}"
 
   prepare-zip:
     name: Prepare module ZIP artifact

--- a/controllers/admin/AdminSaferPayOfficialSettingsController.php
+++ b/controllers/admin/AdminSaferPayOfficialSettingsController.php
@@ -126,24 +126,29 @@ class AdminSaferPayOfficialSettingsController extends ModuleAdminController
 
         if (!$this->validateAjaxToken()) {
             $this->ajaxResponse(false, $this->module->l('Invalid security token', self::FILE_NAME));
-            return;
+
+            return false;
         }
 
         $action = Tools::getValue('action');
         if (!$action || !in_array($action, self::ALLOWED_AJAX_ACTIONS)) {
             $this->ajaxResponse(false, $this->module->l('Invalid action', self::FILE_NAME));
-            return;
+
+            return false;
         }
 
         // Bypassing parent::postProcess() skips PrestaShop's native permission checks,
         // so state-changing actions must explicitly require 'edit' permission.
         if (in_array($action, self::STATE_CHANGING_AJAX_ACTIONS) && !$this->access('edit')) {
             $this->ajaxResponse(false, $this->module->l('You do not have permission to edit these settings.', self::FILE_NAME));
-            return;
+
+            return false;
         }
 
         $methodName = 'ajaxProcess' . ucfirst($action);
         $this->{$methodName}();
+
+        return true;
     }
 
     /**

--- a/src/Service/SaferPayOrderStatusService.php
+++ b/src/Service/SaferPayOrderStatusService.php
@@ -24,7 +24,6 @@
 namespace Invertus\SaferPay\Service;
 
 use Cart;
-use Customer;
 use Exception;
 use Invertus\SaferPay\Adapter\LegacyContext;
 use Invertus\SaferPay\Api\Enum\TransactionStatus;
@@ -32,8 +31,6 @@ use Invertus\SaferPay\Api\Request\CancelService;
 use Invertus\SaferPay\Api\Request\CaptureService;
 use Invertus\SaferPay\Api\Request\RefundService;
 use Invertus\SaferPay\Config\SaferPayConfig;
-use Invertus\SaferPay\DTO\Request\PendingNotification;
-use Invertus\SaferPay\Enum\ControllerName;
 use Invertus\SaferPay\Exception\Api\SaferPayApiException;
 use Invertus\SaferPay\Factory\ModuleFactory;
 use Invertus\SaferPay\Logger\LoggerInterface;


### PR DESCRIPTION
## Self-Checks
- [x] I have performed a self-review of my code.
- [ ] I have updated/added necessary technical documentation in the [README](/README.md) file.

## JIRA task link
SL-382

## Summary
The CI/CD pipeline has been dead since around May 2026, so lint and phpstan have not run on this module for months while the admin redesign landed. This makes them run again without depending on the private `ps-module-workspace` repository, and fixes the two findings that turning them back on exposed.

## QA Checklist Labels
- [x] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [x] Improvement? <!-- Maps to "improvement" label -->
- [x] Technical debt? <!-- Maps to "debt" label -->
- [ ] Reusable? <!-- Maps to "reuse" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->

## QA Checklist
Blocks the 2.1.0 release together with #330 (React bundle built in CI) and #339 (Composer advisory release-build fix).

## Additional Context

### Root cause

Every run died in the very first real step:

```
Identity added: (stdin) (marijus@Marijuss-MacBook-Pro.local)
Cloning into '.../workspace'...
ERROR: Repository not found.
##[error]Process completed with exit code 128.
```

`ssh-add` succeeds, so the secret `PS_MODULE_WORKSPACE_SAFERPAY_PRIVATE_KEY` is intact. The key is a **personal** key (note the identity comment) and the account it belongs to is no longer on the collaborator list of `Invertus/ps-module-workspace`, so GitHub authenticates the key and then reports the private repo as not found. Last green run was 2025-11-21; failures start 2026-05-08.

Restoring a credential would mean either a read-only deploy key on `ps-module-workspace` (needs admin on that repo) or another personal token with the same expiry and offboarding fragility. So the dependency is removed instead.

### What changed

`lint` and `phpstan` need the PrestaShop sources on disk and the matching PHP version. They do not need a running shop, a database or a healthcheck. The public `prestashop/prestashop:1.7.8-7.4` image already ships the sources, so it is now started idle with the checked-out module mounted in place:

```yaml
docker run -d --name ps-lint \
  -v ${{ github.workspace }}:/var/www/html/modules/saferpayofficial \
  --entrypoint tail prestashop/prestashop:${{ matrix.PS }} -f /dev/null
```

That drops seven steps: the workspace clone, `docker compose up`, the healthcheck, the swap-space allocation, and the in-container `git clone` plus branch checkout of this module. As a side effect the job now tests the actual checked-out code instead of re-cloning the branch from GitHub inside the container, which also means it works for pull requests from forks. `git` and `composer` are installed into the container since the base image ships neither.

`fail-fast: false` added on the matrix, so a red `lint` leg no longer cancels `phpstan`.

### Findings this exposed, both fixed here

- `src/Service/SaferPayOrderStatusService.php` - three unused imports (`Customer`, `PendingNotification`, `ControllerName`), each referenced nowhere but its own `use` line. php-cs-fixer error 8.
- `controllers/admin/AdminSaferPayOfficialSettingsController.php` - `postProcess()` had bare `return;` statements and no return at the end, while the inherited signature is `bool|ObjectModel`. Now returns `false` on each rejected request and `true` after dispatching. Behaviour is unchanged: `ajaxResponse()` ends in `sendJsonResponse()` which calls `die()`, so those returns are unreachable defensive paths.

### Verification

Ran the exact steps of the new workflow locally against `prestashop/prestashop:1.7.8-7.4` on a clean clone of the release branch.

Before the fixes, both suites reported real failures, which is the proof they had genuinely stopped running:

```
make ci-lint     -> Error 8, 1) src/Service/SaferPayOrderStatusService.php
make ci-phpstan  -> [ERROR] Found 1 error
                    postProcess() should return bool|ObjectModel but return statement is missing
```

After:

```
make ci-lint                             -> exit=0, Checked all files
make ci-phpstan ps_version_tag=1.7.8-7.4 -> exit=0, Detected PS version 1.7.8.11, [OK] No errors (267 files)
```

`composer install` and the on-the-fly `composer require phpstan/phpstan` both succeeded, which incidentally re-confirms the advisory policy fix from #339 works during dependency resolution.

### Follow-up worth considering

Other Invertus modules use the same `ps-module-workspace` harness with their own personal-key secrets, so they will break the same way whenever those accounts are offboarded. Either move them to read-only deploy keys, or apply this self-contained pattern.

## Frontend Changes
None.