### PR TITLE
Remove files deleted in 2.1.0 during the module upgrade

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -216,3 +216,4 @@
 - API update to V1.50: added WERO and GIFTCARD payment methods, removed deprecated GIROPAY/PAYDIREKT/SOFORT
 - BO : Fixed issue when a freshly installed module logged an account error before any API credentials were entered
 - BO : Fixed issue when the "Could not reach your Saferpay account" warning kept showing after payment methods had loaded successfully
+- Fixed issue when files removed in this version stayed on disk after an upgrade, leaving obsolete iframe checkout controllers reachable and re-creating obsolete menu tabs on module reset

--- a/upgrade/install-2.1.0.php
+++ b/upgrade/install-2.1.0.php
@@ -27,6 +27,17 @@ if (!defined('_PS_VERSION_')) {
 
 function upgrade_module_2_1_0()
 {
+    saferpayofficial_2_1_0_delete_removed_tabs();
+    saferpayofficial_2_1_0_delete_removed_files();
+    saferpayofficial_2_1_0_delete_removed_configuration();
+
+    Tools::clearSmartyCache();
+
+    return true;
+}
+
+function saferpayofficial_2_1_0_delete_removed_tabs()
+{
     $removedTabs = ['AdminSaferPayOfficialPayment', 'AdminSaferPayOfficialFields'];
 
     foreach ($removedTabs as $className) {
@@ -38,6 +49,108 @@ function upgrade_module_2_1_0()
         $tab = new Tab($tabId);
         $tab->delete();
     }
+}
 
-    return true;
+/**
+ * A ZIP upgrade overwrites files but never removes the ones a new version dropped,
+ * so everything deleted in 2.1.0 stays on disk and stays reachable:
+ * the leftover admin controller is re-registered as a tab by PrestaShop on the next
+ * module reset, and the leftover iframe front controllers keep answering, one of them
+ * still reaching the checkout processor with the payment method taken from the request.
+ * Both fatal on removed class constants, so they can only be cleaned up from here.
+ */
+function saferpayofficial_2_1_0_delete_removed_files()
+{
+    $moduleDir = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+
+    $removedFiles = [
+        'controllers/admin/AdminSaferPayOfficialFieldsController.php',
+        'controllers/front/failIFrame.php',
+        'controllers/front/hostedIframe.php',
+        'controllers/front/iframe.php',
+        'controllers/front/successIFrame.php',
+        'src/Entity/index.php',
+        'src/Service/SaferPayTerminalService.php',
+        'views/css/admin/saferpay_fields.css',
+        'views/css/front/hosted-templates/index.php',
+        'views/css/front/hosted-templates/template1.css',
+        'views/css/front/hosted-templates/template2.css',
+        'views/css/front/hosted-templates/template3.css',
+        'views/css/front/saferpay_iframe.css',
+        'views/img/example-card/credit-card-back-cvc.png',
+        'views/img/example-card/credit-card-back.png',
+        'views/img/example-card/credit-card-front-card-number.png',
+        'views/img/example-card/credit-card-front-expiration.png',
+        'views/img/example-card/credit-card-front.png',
+        'views/img/example-card/index.php',
+        'views/img/hosted-templates/index.php',
+        'views/img/hosted-templates/template1.jpg',
+        'views/img/hosted-templates/template2.jpg',
+        'views/img/hosted-templates/template3.jpg',
+        'views/js/front/hosted-templates/template1.js',
+        'views/js/front/hosted-templates/template2.js',
+        'views/js/front/hosted-templates/template3.js',
+        'views/js/front/hosted-templates/template_submit.js',
+        'views/js/front/saferpay_iframe.js',
+        'views/templates/admin/field-option-settings/helpers/index.php',
+        'views/templates/admin/field-option-settings/helpers/options/index.php',
+        'views/templates/admin/field-option-settings/helpers/options/options.tpl',
+        'views/templates/admin/field-option-settings/index.php',
+        'views/templates/admin/partials/field-hosted-field-template-desc.tpl',
+        'views/templates/admin/partials/field-terminal-id.tpl',
+        'views/templates/front/hosted-templates/index.php',
+        'views/templates/front/hosted-templates/partials/all_errors.tpl',
+        'views/templates/front/hosted-templates/partials/all_errors_16.tpl',
+        'views/templates/front/hosted-templates/partials/index.php',
+        'views/templates/front/hosted-templates/partials/initialize_error.tpl',
+        'views/templates/front/hosted-templates/partials/internal_error.tpl',
+        'views/templates/front/hosted-templates/partials/submission_error.tpl',
+        'views/templates/front/hosted-templates/partials/validation_error.tpl',
+        'views/templates/front/hosted-templates/template1.tpl',
+        'views/templates/front/hosted-templates/template2.tpl',
+        'views/templates/front/hosted-templates/template3.tpl',
+        'views/templates/front/saferpay_iframe.tpl',
+    ];
+
+    $parentDirectories = [];
+
+    foreach ($removedFiles as $removedFile) {
+        $path = $moduleDir . str_replace('/', DIRECTORY_SEPARATOR, $removedFile);
+
+        if (!is_file($path)) {
+            continue;
+        }
+
+        @unlink($path);
+        $parentDirectories[dirname($path)] = true;
+    }
+
+    $parentDirectories = array_keys($parentDirectories);
+
+    usort($parentDirectories, function ($first, $second) {
+        return strlen($second) - strlen($first);
+    });
+
+    foreach ($parentDirectories as $parentDirectory) {
+        saferpayofficial_2_1_0_delete_empty_directory($parentDirectory, $moduleDir);
+    }
+}
+
+function saferpayofficial_2_1_0_delete_empty_directory($directory, $moduleDir)
+{
+    while (strpos($directory, $moduleDir) === 0 && is_dir($directory)) {
+        $entries = scandir($directory);
+
+        if ($entries === false || count($entries) > 2) {
+            return;
+        }
+
+        @rmdir($directory);
+        $directory = dirname($directory);
+    }
+}
+
+function saferpayofficial_2_1_0_delete_removed_configuration()
+{
+    Configuration::deleteByName('SAFERPAY_HOSTED_FIELDS_TEMPLATE');
 }


### PR DESCRIPTION
## Problem

A PrestaShop ZIP upgrade overwrites files but never removes the ones a new version dropped. 2.1.0 deletes 46 files, so on every upgraded shop all 46 stay on disk and stay reachable, while a freshly installed shop does not have them.

Two consequences, both observed on a shop that genuinely came through the 2.0.3 -> 2.1.0 ZIP upgrade:

1. `controllers/admin/AdminSaferPayOfficialFieldsController.php` survives, and PrestaShop's `ModuleTabRegister::addUndeclaredTabs()` registers a tab for any `*Controller.php` in `controllers/admin/`. Pressing **Reset** on the module brings the obsolete Saferpay Fields tab back. Opening it is a fatal, because the controller reads `SaferPayConfig::HOSTED_FIELDS_TEMPLATE`, a constant removed in 2.1.0:
   ```
   Error: Undefined constant Invertus\SaferPay\Config\SaferPayConfig::HOSTED_FIELDS_TEMPLATE
   ```
2. Four front controllers survive (`iframe.php`, `hostedIframe.php`, `successIFrame.php`, `failIFrame.php`). Module front controllers dispatch on file presence, not on a DB row, so all four stay routable. `hostedIframe.php` and `successIFrame.php` fatal on removed constants. `iframe.php` is the real problem: it still reaches `CheckoutProcessor` with the payment method taken from a request parameter, an entry point that exists only on upgraded shops and is no longer part of any tested flow.

Only an upgrade script can fix this, since a ZIP cannot delete.

## Change

`upgrade_module_2_1_0()` gains three steps next to the existing tab cleanup:

- unlinks an explicit list of the 46 removed paths, then removes the parent directories that become empty
- deletes the obsolete `SAFERPAY_HOSTED_FIELDS_TEMPLATE` setting, which nothing in 2.1.0 reads
- clears the Smarty cache, so no compiled copy of a deleted `.tpl` is served

The list is explicit rather than directory based on purpose. `views/js/front/hosted-templates/` still holds `hosted_fields.js`, which live 2.1.0 code loads from `src/Presentation/Loader/PaymentFormAssetLoader.php:146`, and four of its siblings in that directory are among the removed files. Same situation in `views/css/front/` and `views/img/`. A directory level delete would break the payment form on every upgraded shop.

## Testing

**On the upgraded shop** (PS 9.1.4 / PHP 8.5, 7 existing Saferpay orders, one captured and refunded in three parts). Captured a render baseline, deleted the 46 files, cleared caches, re-ran the same probe. Before and after are identical:

```
BO order panel (hookDisplayAdminOrderTabContent)
  order 12: OK len=2942 refund=1 capture=1     <- same both runs
FO payment options
  Visa, action=/module/saferpayofficial/validation?saved_card_method=VISA&isBusinessLicence=0
FO asset loader: registered js=2, missing-on-disk=0
hookDisplayCustomerAccount / hookDisplayOrderConfirmation: OK
```

At HTTP level only the intended endpoints change:

```
404  /module/saferpayofficial/iframe          <- was reaching the checkout processor
404  /module/saferpayofficial/hostedIframe
404  /module/saferpayofficial/successIFrame
404  /module/saferpayofficial/failIFrame
301  /module/saferpayofficial/validation      <- unchanged
301  /module/saferpayofficial/return          <- unchanged
301  /module/saferpayofficial/notify          <- unchanged
301  /module/saferpayofficial/creditCards     <- unchanged
```

**On the script itself.** Reproduced the ZIP upgrade on disk (2.0.3 tree with the 2.1.0 ZIP copied over it, 1403 files), then ran `upgrade_module_2_1_0()` against it:

```
before: 1403 files
after:  1357 files
diff vs clean 2.1.0 ZIP (files):       IDENTICAL
diff vs clean 2.1.0 ZIP (directories): IDENTICAL
```

An upgraded shop ends up structurally indistinguishable from a fresh install. Idempotent, verified by running it twice more with no warnings or notices under `E_ALL`. `hosted_fields.js` and the module root are untouched.

`php -l` and `php-cs-fixer --dry-run` clean. phpstan does not scan `upgrade/`.

## Notes for the reviewer

- Existing order data is untouched, the change is file only. Orders created through the old iframe flow still resolve, because `PaymentType::HOSTED_IFRAME`, `PaymentTypeProvider` and `controllers/front/return.php:115` all still ship in 2.1.0. Only the entry point files are gone, not the handling of the stored value.
- The unlinks use `@unlink`, so a file the web user cannot delete is skipped and the upgrade still succeeds. Failing the upgrade over a leftover file would roll the version back, which is worse. The tradeoff is that on a shop with locked down file permissions the orphans survive and this fix silently does nothing.
