### PR TITLE
SL-375 Fix Saferpay Fields CVC and loading states in checkout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -217,3 +217,5 @@
 - BO : Fixed issue when a freshly installed module logged an account error before any API credentials were entered
 - BO : Fixed issue when the "Could not reach your Saferpay account" warning kept showing after payment methods had loaded successfully
 - Fixed issue when files removed in this version stayed on disk after an upgrade, leaving obsolete iframe checkout controllers reachable and re-creating obsolete menu tabs on module reset
+- FO : Fixed issue when the Saferpay Fields CVC field looked editable while the card number was incomplete, showing no cursor and accepting no input
+- FO : Fixed issue when the Saferpay Fields card form accepted clicks and keystrokes while it was still loading, so the first characters typed were invisible and appeared to be lost

--- a/views/css/front/saferpay_checkout.css
+++ b/views/css/front/saferpay_checkout.css
@@ -106,9 +106,33 @@ input[type="radio"][name^="saved_card_"] {
 
 /* While the SDK initialises, each iframe briefly paints with its default input styling
    before our injected stylesheet applies — keep the iframes invisible until the SDK's
-   init onSuccess lifts this class, leaving the outlined fieldsets as loading skeleton. */
+   init onSuccess lifts this class, leaving the outlined fieldsets as loading skeleton.
+   An invisible iframe still takes clicks and keystrokes, so without pointer-events a
+   customer clicking a field during init focuses and types into a field they cannot see:
+   no caret, no characters, and the field reads as broken. */
 .saferpay-inline-fields.saferpay-fields-loading iframe {
     opacity: 0;
+    pointer-events: none;
+}
+
+/* Two states where a field is drawn but cannot be typed into: while the SDK initialises, and
+   while the SDK holds the CVC disabled until the card number passes its CheckCard lookup (the
+   inner input is muted through the injected :disabled rule, see inline-fields.js). Muting the
+   outline and label too means the field reads as unavailable before it is clicked instead of
+   after. Declared ahead of the focus/error rules below so both still take precedence. */
+.saferpay-inline-fields.saferpay-fields-loading .saferpay-field,
+.saferpay-inline-fields .saferpay-field.is-locked {
+    border-color: #e0e0e0;
+    background: #f7f8f8;
+}
+
+.saferpay-inline-fields.saferpay-fields-loading .saferpay-field legend,
+.saferpay-inline-fields .saferpay-field.is-locked legend {
+    color: #9aa4a8;
+}
+
+.saferpay-inline-fields.saferpay-fields-loading .saferpay-field {
+    cursor: progress;
 }
 
 /* Focus feedback: the SDK's own focus styling is cleared (it shrank the field), so the

--- a/views/js/front/inline-fields.js
+++ b/views/js/front/inline-fields.js
@@ -47,6 +47,13 @@
     // rebuild+re-init when the same option fires a spurious change event.
     var renderedContainerId = null;
 
+    // The loading state makes the fields inert, so it must not outlive an init callback that
+    // never arrives: a silently failed SDK init would otherwise leave a form nobody can type
+    // into. Generous on purpose: it is a last resort, not the normal path (init is well under
+    // a second), and lifting it early would show the fields before they are styled.
+    var LOADING_TIMEOUT = 10000;
+    var loadingTimeout = null;
+
     // The customer-entered card inputs live in cross-origin Saferpay iframes, so their
     // validity is only known through the SDK's onValidated callback. It fires when a field
     // loses focus; an untouched field never fires it. We therefore default every required
@@ -103,10 +110,12 @@
             '</fieldset>';
     }
 
-    // The slot starts in the "loading" state: the field iframes are kept invisible until
-    // the SDK reports successful initialisation, because each iframe first paints with the
-    // SDK's default input styling and only then applies our injected stylesheet — showing
-    // it earlier flashes an unstyled square input inside the outlined field.
+    // The slot starts in the "loading" state: the field iframes are kept invisible and inert
+    // until the SDK reports successful initialisation, because each iframe first paints with
+    // the SDK's default input styling and only then applies our injected stylesheet, so
+    // showing it earlier flashes an unstyled square input inside the outlined field. The
+    // fieldsets render muted while it lasts (see saferpay_checkout.css), because a field that
+    // looks ready but silently drops the click reads as broken.
     function fieldsFormMarkup() {
         return '' +
             '<div id="' + SLOT_ID + '" class="saferpay-inline-fields saferpay-fields-loading">' +
@@ -146,7 +155,16 @@
         return parseInt($form.find('[name="selectedCreditCard_' + method + '"]').val(), 10) || 0;
     }
 
+    function stopLoading() {
+        if (loadingTimeout) {
+            clearTimeout(loadingTimeout);
+            loadingTimeout = null;
+        }
+        $('#' + SLOT_ID).removeClass('saferpay-fields-loading');
+    }
+
     function removeSlot() {
+        stopLoading();
         $('#' + SLOT_ID).remove();
         renderedContainerId = null;
     }
@@ -165,6 +183,7 @@
 
         $container.append(fieldsFormMarkup());
         renderedContainerId = containerId;
+        loadingTimeout = setTimeout(stopLoading, LOADING_TIMEOUT);
 
         SaferpayFields.init({
             accessToken: saferpay_field_access_token,
@@ -193,15 +212,22 @@
             // feedback is shown on the fieldset outline instead.
             style: {
                 '.form-control': 'box-sizing: border-box; width: 100%; margin: 0; padding: 4px 0 12px; border: none; outline: none; background: transparent; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif; font-size: 17px; line-height: normal; color: #1f2426; caret-color: rgb(39, 119, 119);',
-                '.form-control:focus': 'border: none; outline: none; box-shadow: none;'
+                '.form-control:focus': 'border: none; outline: none; box-shadow: none;',
+                // The SDK keeps the CVC input disabled until the card number passes its
+                // CheckCard lookup. Without this rule the .form-control declarations above
+                // apply to it unchanged, so a disabled field is indistinguishable from an
+                // editable one: text cursor on hover, live caret colour, normal text colour.
+                // Customers click it, get no caret, and read the field as broken. Blink and
+                // WebKit override `color` on a disabled input, hence -webkit-text-fill-color.
+                '.form-control:disabled': 'cursor: not-allowed; color: #9aa4a8; -webkit-text-fill-color: #9aa4a8; caret-color: transparent;'
             },
             // Reveal the field iframes only once the SDK reports them fully loaded (inner
             // stylesheet included) — see the loading-state note on fieldsFormMarkup.
             onSuccess: function () {
-                $('#' + SLOT_ID).removeClass('saferpay-fields-loading');
+                stopLoading();
             },
             onError: function (evt) {
-                $('#' + SLOT_ID).removeClass('saferpay-fields-loading');
+                stopLoading();
                 $('#' + SLOT_ID + ' .initialize-error-message').text(evt.message);
                 $('#' + SLOT_ID + ' .initialize-error').show();
             },
@@ -213,10 +239,26 @@
                     fieldValidity[evt.fieldType] = !!evt.isValid;
                 }
                 toggleFieldClass(evt.fieldType, 'has-error', !evt.isValid);
+
+                // The SDK disables the CVC input whenever the card number fails its CheckCard
+                // lookup, and exposes no callback for that. Card-number validity is the same
+                // condition it gates on, so it stands in as the lock signal. An untouched
+                // card number leaves the CVC enabled, which is why this only reacts to
+                // onValidated and the field is not rendered locked.
+                if (evt.fieldType === 'cardnumber') {
+                    toggleFieldClass('cvc', 'is-locked', !evt.isValid);
+                }
             },
             onFocus: function (evt) {
                 if (evt) {
                     toggleFieldClass(evt.fieldType, 'is-focused', true);
+
+                    // A disabled input cannot take focus, so reaching the CVC field proves
+                    // the SDK has unlocked it. The card number may not have blurred yet,
+                    // which is what onValidated waits for.
+                    if (evt.fieldType === 'cvc') {
+                        toggleFieldClass('cvc', 'is-locked', false);
+                    }
                 }
             },
             onBlur: function (evt) {


### PR DESCRIPTION
QA follow-up on SL-375. Two states where a Saferpay Fields card field is drawn as fully usable while it cannot be typed into, so the form reads as broken.

## 1. CVC field looks editable while the card number is incomplete

The SDK keeps the CVC input `disabled` until the card number passes its `CheckCard` lookup, and the injected `.form-control` rule had no `:disabled` variant. The disabled input therefore kept the text cursor on hover, the normal text colour and a live caret colour, so clicking it gave no caret and dropped every keystroke.

- Added `.form-control:disabled` to the injected style: `cursor: not-allowed`, muted colour and `caret-color: transparent`. `-webkit-text-fill-color` is required because Blink and WebKit override `color` on a disabled input.
- Mirrored the lock on our own fieldset with an `is-locked` class, driven by card-number validity in `onValidated` and cleared in `onFocus` for the CVC (a disabled input cannot take focus, so reaching it proves the SDK unlocked it).

The field is deliberately **not** rendered pre-locked: with an untouched card number the CVC is genuinely enabled and typeable, so pre-locking would grey out a usable field.

| card number state | `disabled` | `cursor` | text fill | caret | fieldset |
|---|---|---|---|---|---|
| pristine, empty | false | `text` | `rgb(31,36,38)` | visible | normal |
| `1234567890123456`, blurred | true | `not-allowed` | `rgb(154,164,168)` | transparent | locked |
| `4111111111111111`, blurred | false | `text` | `rgb(31,36,38)` | visible | normal |

## 2. Card form accepted clicks and keystrokes while still loading

The field iframes were hidden with `opacity: 0` until the SDK reported success. An `opacity: 0` iframe still hit-tests, so a customer clicking a field during init focused the invisible input and the characters they typed landed in a field they could not see. Verified: typed `GHOST` during the window and it went into the holder-name input.

Measured window from selecting the payment option, on a low-latency connection:

| time | state | what a click did |
|---|---|---|
| 0-400 ms | placeholder only, no iframe | swallowed, focus on `BODY` |
| 400-600 ms | iframe present, `opacity: 0` | focused and typed into an invisible input |
| 600-800 ms | fading in | partially visible |

- `pointer-events: none` alongside `opacity: 0`, so the field is inert while hidden.
- The fieldsets render muted (grey border, grey background, grey legend, `cursor: progress`), sharing declarations with `is-locked` since both mean "drawn but not typeable". Both are declared ahead of the focus/error rules so those still take precedence.
- The 0-400 ms window cannot be fixed at all (there is nothing to click yet), only made legible.

### Fallback timeout

The loading class now also has a 10s fallback, cleared in `onSuccess`, `onError` and `removeSlot`. Verified by blocking the field iframe requests: **the SDK calls neither `onSuccess` nor `onError`**, so a class gated only on those callbacks stays on forever. Combined with `pointer-events: none` that would leave the form permanently inert, which is worse than the original bug. With the timer it recovers.

## Not changed, ruled out with evidence

The unconditional `cvc` entry in the submit gate's `REQUIRED_FIELDS` was suspected of deadlocking cards without a mandatory CVC. Bancontact BIN `6703444444444449` (`isCvcMandatory: false`) with a blank CVC returned `{"success":true}` from `Store` and the gate did not block: the SDK reports an empty CVC as valid when it is not mandatory. `reEnablePlaceOrder()` also already covers all four failure branches.

## Testing

PS 8.2.3 / PHP 8.1, Chromium, live test terminal. All four field states verified through the real cross-origin iframes, including that the injected `:disabled` rule reaches the iframe's own `document.styleSheets`. Also checked that the muted loading and locked looks do not override `has-error` or `is-focused`, that typing works normally once ready (`JOHN DOE`, CVC `456`), and that a full submit still reaches `Store`.

Changelog updated in the 2.1.0 section.
