### PR TITLE
Fix API password field having no editable state or visible control

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -217,3 +217,4 @@
 - BO : Fixed issue when a freshly installed module logged an account error before any API credentials were entered
 - BO : Fixed issue when the "Could not reach your Saferpay account" warning kept showing after payment methods had loaded successfully
 - Fixed issue when files removed in this version stayed on disk after an upgrade, leaving obsolete iframe checkout controllers reachable and re-creating obsolete menu tabs on module reset
+- BO : Fixed issue when a saved API password offered no visible way to enter a new one, and browser password manager icons covered the show/hide password control

--- a/src/Service/SettingsTranslationService.php
+++ b/src/Service/SettingsTranslationService.php
@@ -118,6 +118,8 @@ class SettingsTranslationService
             'enterApiPassword' => $this->module->l('Enter %s API password', self::FILE_NAME),
             'hidePassword' => $this->module->l('Hide password', self::FILE_NAME),
             'showPassword' => $this->module->l('Show password', self::FILE_NAME),
+            'changePassword' => $this->module->l('Change password', self::FILE_NAME),
+            'passwordSavedHint' => $this->module->l('Password saved. Click the pencil icon to enter a new one.', self::FILE_NAME),
             'terminalId' => $this->module->l('Terminal ID', self::FILE_NAME),
             'selectTerminal' => $this->module->l('Select a terminal', self::FILE_NAME),
             'refreshTerminals' => $this->module->l('Refresh terminals', self::FILE_NAME),

--- a/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
+++ b/views/js/admin/settings-app/src/components/settings/api-credentials.tsx
@@ -4,7 +4,7 @@ import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { AlertCircle, Eye, EyeOff, Key, Shield, Loader2, Info, CheckCircle2, Wand2, XCircle } from 'lucide-react'
+import { AlertCircle, Eye, EyeOff, Key, Shield, Loader2, Info, CheckCircle2, Wand2, XCircle, Pencil } from 'lucide-react'
 import { useSettings } from '@/context/settings-context'
 import { toast } from '@/hooks/use-toast'
 import { t } from '@/utils/translations'
@@ -68,7 +68,6 @@ export function ApiCredentials() {
     if (!hasCredentials) {
       setCredentialStatus('idle')
       setCredentialError('')
-      setTerminals([])
       return
     }
 
@@ -195,6 +194,10 @@ export function ApiCredentials() {
                   placeholder={t('enterApiUsername', envLabel.toLowerCase())}
                   value={username}
                   onChange={(e) => setField('username', e.target.value)}
+                  data-lpignore="true"
+                  data-1p-ignore=""
+                  data-bwignore="true"
+                  data-form-type="other"
                   required
                   aria-required="true"
                 />
@@ -210,10 +213,26 @@ export function ApiCredentials() {
                     placeholder={t('enterApiPassword', envLabel.toLowerCase())}
                     value={password}
                     onChange={(e) => setField('password', e.target.value)}
-                    className={isStoredPasswordMasked ? undefined : 'sp-pr-10'}
+                    readOnly={isStoredPasswordMasked}
+                    className="!sp-pr-10"
+                    data-lpignore="true"
+                    data-1p-ignore=""
+                    data-bwignore="true"
+                    data-form-type="other"
                     required
                     aria-required="true"
                   />
+                  {isStoredPasswordMasked && (
+                    <button
+                      type="button"
+                      onClick={() => setField('password', '')}
+                      className="sp-absolute sp-right-3 sp-top-1/2 sp--translate-y-1/2 sp-text-muted-foreground hover:sp-text-foreground sp-transition-colors sp-p-1 sp-min-w-[24px] sp-min-h-[24px] sp-flex sp-items-center sp-justify-center"
+                      aria-label={t('changePassword')}
+                      title={t('changePassword')}
+                    >
+                      <Pencil className="sp-h-4 sp-w-4" />
+                    </button>
+                  )}
                   {showPasswordToggle && (
                     <button
                       type="button"
@@ -225,6 +244,9 @@ export function ApiCredentials() {
                     </button>
                   )}
                 </div>
+                {isStoredPasswordMasked && (
+                  <p className="sp-text-xs sp-text-muted-foreground">{t('passwordSavedHint')}</p>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
Found in testing, not from an existing ticket: on the settings page, with a saved API password and LastPass paused for the site, the password field showed no eye icon and no other control.

## Cause

A stored password renders as a masked placeholder, and the show/hide toggle is gated on the field holding a real value (`password.length > 0 && !isStoredPasswordMasked`). In the masked state there was therefore no control at all, while the field still looked like an ordinary editable password input. Typing into it did nothing useful, and with a password manager paused there was not even an injected manager icon to explain the gap. When a manager was active, its icon sat on top of the same corner as our toggle.

## Changes

- A masked stored password is now `readOnly` and carries a pencil button that clears the field so a new password can be typed, plus a hint line under the input. The eye toggle still appears once a real value is being entered. The two are mutually exclusive by construction, so they cannot overlap.
- Right padding is now unconditional, so the value can never run under whichever control is showing.
- Both credential inputs opt out of password managers with `data-lpignore`, `data-1p-ignore`, `data-bwignore` and `data-form-type="other"`.
- Two new translation strings: `changePassword`, `passwordSavedHint`.

## Related, but not this PR: SL-377

SL-377 is a different bug (a stored password corrupted or overwritten on save, causing 401). It lists browser autofill as its second suspected cause and names `data-lpignore="true"` in its fix direction, so the password-manager opt-out here happens to harden that one path on the new React settings page. Everything else in SL-377 is untouched and it should not be closed on the back of this PR: the confirmed double-escaping in `views/templates/admin/field-option-settings/helpers/options/options.tpl` and `autocomplete="off"` on the inputs are still open.

## One behavioural change worth a look

`setTerminals([])` is removed from the "no credentials" branch of the credential-check effect. The pencil deliberately empties the password field, and clearing the terminals there would blank the Terminal ID dropdown while the merchant retypes their password. Switching environment and a failed credential check both still clear the list, so the only remaining case that keeps a stale list is a merchant manually emptying the credential fields, where it is replaced as soon as a valid pair is entered.

## Testing

- `tsc --noEmit` clean, `vite build` succeeds (329.78 kB bundle), `php -l` clean on the translation service.
- UI behaviour was verified manually by the reporter on PS 8.2.3.
- `views/js/admin/dist/` is gitignored, so no built assets are part of this PR.

Changelog updated in the 2.1.0 section.
